### PR TITLE
New Sample : Fully Compose Activity

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -7,6 +7,8 @@ dependencies {
   implementation 'com.squareup.retrofit2:converter-scalars:2.9.0'
   implementation 'com.squareup.okhttp3:okhttp:4.9.2'
   implementation 'com.squareup.okhttp3:logging-interceptor:4.9.2'
+  implementation "androidx.activity:activity-compose:1.4.0"
+  implementation "androidx.compose.material:material:1.0.4"
 
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'app.cash.molecule:molecule-testing'
@@ -15,6 +17,7 @@ dependencies {
 android {
   buildFeatures {
     viewBinding true
+    compose true
   }
 
   testOptions {

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -13,5 +13,8 @@
         <category android:name="android.intent.category.DEFAULT"/>
       </intent-filter>
     </activity>
+    <activity
+      android:name=".compose.CounterComposeActivity"
+      android:exported="true" />
   </application>
 </manifest>

--- a/sample/src/main/java/com/example/molecule/compose/Counter.kt
+++ b/sample/src/main/java/com/example/molecule/compose/Counter.kt
@@ -1,0 +1,70 @@
+package com.example.molecule.compose
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.molecule.CounterModel
+
+@Composable
+fun Counter(
+    counter: CounterModel,
+    onDecreaseTenClick: () -> Unit,
+    onDecreaseOneClick: () -> Unit,
+    onIncreaseTenClick: () -> Unit,
+    onIncreaseOneClick: () -> Unit,
+    onRandomizeClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(20.dp)
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.SpaceEvenly,
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Button(
+                onClick = onDecreaseTenClick,
+                enabled = !counter.loading
+            ) {
+                Text(text = "-10")
+            }
+            Button(
+                onClick = onDecreaseOneClick,
+                enabled = !counter.loading
+            ) {
+                Text(text = "-1")
+            }
+            Text(text = counter.value.toString(), fontSize = 20.sp)
+            Button(
+                onClick = onIncreaseOneClick,
+                enabled = !counter.loading
+            ) {
+                Text(text = "+1")
+            }
+            Button(
+                onClick = onIncreaseTenClick,
+                enabled = !counter.loading
+            ) {
+                Text(text = "+10")
+            }
+        }
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        Button(
+            onClick = onRandomizeClick,
+            enabled = !counter.loading,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(text = "Randomize")
+        }
+    }
+}

--- a/sample/src/main/java/com/example/molecule/compose/CounterComposeActivity.kt
+++ b/sample/src/main/java/com/example/molecule/compose/CounterComposeActivity.kt
@@ -1,0 +1,51 @@
+package com.example.molecule.compose
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import app.cash.molecule.AndroidUiDispatcher.Companion.Main
+import app.cash.molecule.launchMolecule
+import com.example.molecule.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableSharedFlow
+
+class CounterComposeActivity : ComponentActivity() {
+    private val scope = CoroutineScope(Main)
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val randomService = RandomService()
+        val events = MutableSharedFlow<CounterEvent>(extraBufferCapacity = 1)
+        val models = scope.launchMolecule { CounterPresenter(events, randomService) }
+        setContent {
+            val counterModel by models.collectAsState()
+            Counter(
+                counter = counterModel,
+                onDecreaseTenClick = {
+                    events.tryEmit(Change(-10))
+                },
+                onDecreaseOneClick = {
+                    events.tryEmit(Change(-1))
+                },
+                onIncreaseTenClick = {
+                    events.tryEmit(Change(10))
+                },
+                onIncreaseOneClick = {
+                    events.tryEmit(Change(1))
+                },
+                onRandomizeClick = {
+                    events.tryEmit(Randomize)
+                }
+            )
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        scope.cancel()
+    }
+}


### PR DESCRIPTION
## Changes

- Adds a new fully compose activity sample (without XML/viewBinding)

## Why do we need this PR?

The main target of this PR is not to get it merged, but more like "review-only" or for "later-reference". But if you think this will be useful, I'd be much happier to see this merged 😉 

## Output

https://user-images.githubusercontent.com/9678279/142777319-3d937a5e-8428-4a22-b6d6-000e42841d07.mp4

