### PR TITLE
Add expectNoEvents to MoleculeTurbine

### DIFF
--- a/molecule/molecule-testing/src/commonTest/java/app/cash/molecule/testing/MoleculeTestingTest.kt
+++ b/molecule/molecule-testing/src/commonTest/java/app/cash/molecule/testing/MoleculeTestingTest.kt
@@ -37,7 +37,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Ignore
 import org.junit.Test
 import kotlin.test.assertFailsWith
-import kotlin.test.fail
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
 
@@ -271,12 +270,8 @@ class MoleculeTestingTest {
   @Test
   fun expectNoEventsFail() {
     testMolecule({}) {
-      try {
-        expectNoEvents()
-        fail()
-      } catch (t: AssertionError) {
-        assertEquals(t.message, "Expected no events but found Item(kotlin.Unit)")
-      }
+      val t = assertFailsWith<AssertionError> { expectNoEvents() }
+      assertEquals(t.message, "Expected no events but found Item(kotlin.Unit)")
     }
   }
 }

--- a/molecule/molecule-testing/src/commonTest/java/app/cash/molecule/testing/MoleculeTestingTest.kt
+++ b/molecule/molecule-testing/src/commonTest/java/app/cash/molecule/testing/MoleculeTestingTest.kt
@@ -37,6 +37,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Ignore
 import org.junit.Test
 import kotlin.test.assertFailsWith
+import kotlin.test.fail
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
 
@@ -257,5 +258,25 @@ class MoleculeTestingTest {
 
     assertSame(validateException, thrown)
     assertSame(moleculeException, thrown.suppressed.single())
+  }
+
+  @Test
+  fun expectNoEvents() {
+    testMolecule({}) {
+      awaitItem()
+      expectNoEvents()
+    }
+  }
+
+  @Test
+  fun expectNoEventsFail() {
+    testMolecule({}) {
+      try {
+        expectNoEvents()
+        fail()
+      } catch (t: AssertionError) {
+        assertEquals(t.message, "Expected no events but found Item(kotlin.Unit)")
+      }
+    }
   }
 }

--- a/molecule/molecule-testing/src/main/java/app/cash/molecule/testing/moleculeTesting.kt
+++ b/molecule/molecule-testing/src/main/java/app/cash/molecule/testing/moleculeTesting.kt
@@ -124,6 +124,13 @@ interface MoleculeTurbine<T> {
    * @throws kotlinx.coroutines.TimeoutCancellationException if no event was received in time.
    */
   public suspend fun awaitError(): Throwable
+
+  /**
+   * Assert that there are no unconsumed events which have already been received.
+   *
+   * @throws AssertionError if unconsumed events are found.
+   */
+  public fun expectNoEvents()
 }
 
 public sealed class Event<out T> {
@@ -177,6 +184,13 @@ private class TickOnDemandMoleculeTurbine<T>(
       unexpectedEvent(event, "error")
     }
     return event.throwable
+  }
+
+  override fun expectNoEvents() {
+    val event = events.tryReceive().getOrNull()
+    if (event != null) {
+      unexpectedEvent(event, "no events")
+    }
   }
 
   private fun unexpectedEvent(event: Event<*>, expected: String): Nothing {


### PR DESCRIPTION
Please close if this is silly or useless, but I don't see another way of verifying this behavior other than expecting a timeout, which extends the runtime of a test by a full second.