### PR TITLE
Bump Compose compiler to 1.3.0 final

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -2,7 +2,7 @@ buildscript {
   ext.versions = [
     'compileSdk': 31,
     'minSdk': 21,
-    'compose': '1.3.0-rc01',
+    'compose': '1.3.0',
     'coroutines': '1.6.4',
     'kotlin': '1.7.10',
   ]


### PR DESCRIPTION
This version supports Kotlin 1.7.10, which we're already on.