### PR TITLE
Fix some opt-in usage

### DIFF
--- a/molecule/molecule-runtime/build.gradle
+++ b/molecule/molecule-runtime/build.gradle
@@ -76,12 +76,6 @@ android {
   }
 }
 
-tasks.withType(KotlinCompile).configureEach {
-  kotlinOptions {
-    freeCompilerArgs += '-Xopt-in=kotlin.RequiresOptIn'
-  }
-}
-
 spotless {
   kotlin {
     targetExclude(

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -26,7 +26,7 @@ android {
 tasks.withType(org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompile).configureEach { task ->
   task.kotlinOptions {
     freeCompilerArgs += [
-      '-Xopt-in=kotlinx.coroutines.ExperimentalCoroutinesApi',
+      '-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi',
     ]
   }
 }


### PR DESCRIPTION
As of Kotlin 1.7 we no longer need to opt-in to the @RequiresOptIn annotation.

Additionally, the command-line argument changed from being behind -X to its own flag.