### PR TITLE
JetBrains Compose runtime beta01

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v3

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-compileSdk = "31"
+compileSdk = "33"
 minSdk = "21"
 
 compose = "1.3.0"
@@ -16,8 +16,8 @@ androidx-core = { module = "androidx.core:core-ktx", version = "1.2.0" }
 androidx-test-runner = { module = "androidx.test:runner", version = "1.2.0" }
 
 compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "compose" }
-compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version = "1.1.0" }
-compose-rx2 = { module = "androidx.compose.runtime:runtime-rxjava2", version = "1.1.0" }
+compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version = "1.2.0-beta01" }
+compose-rx2 = { module = "androidx.compose.runtime:runtime-rxjava2", version = "1.2.1" }
 
 dokka-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "1.6.10" }
 

--- a/molecule/molecule-runtime/build.gradle
+++ b/molecule/molecule-runtime/build.gradle
@@ -10,10 +10,30 @@ kotlin {
   android {
     publishLibraryVariants('release')
   }
+
+  iosArm64()
+  iosSimulatorArm64()
+  iosX64()
+
   js {
     nodejs()
   }
   jvm()
+
+  linuxX64()
+
+  macosArm64()
+  macosX64()
+
+  mingwX64()
+
+  tvosArm64()
+  tvosSimulatorArm64()
+  tvosX64()
+
+  watchosArm64()
+  watchosSimulatorArm64()
+  watchosX64()
 
   sourceSets {
     commonMain {


### PR DESCRIPTION
This brings all of the native targets possible (as limited by kotlinx.coroutines).

Closes #2 