### PR TITLE
Add foundation of sample that uses AAC ViewModel

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,10 @@ squareup-retrofit = "2.9.0"
 android-plugin = { module = "com.android.tools.build:gradle", version = "7.3.1" }
 androidx-core = { module = "androidx.core:core-ktx", version = "1.9.0" }
 androidx-test-runner = { module = "androidx.test:runner", version = "1.5.2" }
+androidx-activity-compose = { module = "androidx.activity:activity-compose", version = "1.6.1" }
+
+androidx-compose-bom = { module = "androidx.compose:compose-bom", version = "2022.11.00" }
+androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
 
 compose-compiler = { module = "org.jetbrains.compose.compiler:compiler", version.ref = "compose" }
 compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version = "1.2.2" }

--- a/sample-viewmodel/build.gradle
+++ b/sample-viewmodel/build.gradle
@@ -1,0 +1,9 @@
+apply plugin: 'com.android.application'
+apply plugin: 'org.jetbrains.kotlin.android'
+apply plugin: 'app.cash.molecule'
+
+dependencies {
+  implementation platform(libs.androidx.compose.bom)
+  implementation libs.androidx.activity.compose
+  implementation libs.androidx.compose.material3
+}

--- a/sample-viewmodel/src/main/AndroidManifest.xml
+++ b/sample-viewmodel/src/main/AndroidManifest.xml
@@ -1,0 +1,20 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.example.molecule.viewmodel">
+  <uses-permission android:name="android.permission.INTERNET"/>
+
+  <application
+    android:label="ViewModel Sample"
+    android:theme="@android:style/Theme.DeviceDefault.NoActionBar"
+    >
+    <activity
+      android:name=".RandomDogActivity"
+      android:exported="true"
+      >
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN"/>
+        <category android:name="android.intent.category.LAUNCHER"/>
+        <category android:name="android.intent.category.DEFAULT"/>
+      </intent-filter>
+    </activity>
+  </application>
+</manifest>

--- a/sample-viewmodel/src/main/java/com/example/molecule/viewmodel/MoleculeViewModel.kt
+++ b/sample-viewmodel/src/main/java/com/example/molecule/viewmodel/MoleculeViewModel.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.molecule.viewmodel
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.AndroidUiDispatcher
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import app.cash.molecule.RecompositionClock.ContextClock
+import app.cash.molecule.launchMolecule
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.StateFlow
+
+abstract class MoleculeViewModel<Event, Model> : ViewModel() {
+  private val scope = CoroutineScope(viewModelScope.coroutineContext + AndroidUiDispatcher.Main)
+
+  // Events have a capacity large enough to handle simultaneous UI events, but
+  // small enough to surface issues if they get backed up for some reason.
+  private val events = MutableSharedFlow<Event>(extraBufferCapacity = 20)
+
+  val models: StateFlow<Model> by lazy(LazyThreadSafetyMode.NONE) {
+    scope.launchMolecule(clock = ContextClock) {
+      models(events)
+    }
+  }
+
+  fun take(event: Event) {
+    if (!events.tryEmit(event)) {
+      error("Event buffer overflow.")
+    }
+  }
+
+  @Composable
+  protected abstract fun models(events: Flow<Event>): Model
+}

--- a/sample-viewmodel/src/main/java/com/example/molecule/viewmodel/RandomDogActivity.kt
+++ b/sample-viewmodel/src/main/java/com/example/molecule/viewmodel/RandomDogActivity.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.molecule.viewmodel
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+
+class RandomDogActivity : ComponentActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    val viewModel by viewModels<RandomDogViewModel>()
+    setContent {
+      MaterialTheme {
+        val model by viewModel.models.collectAsState()
+        RandomDogScreen(model)
+      }
+    }
+  }
+}

--- a/sample-viewmodel/src/main/java/com/example/molecule/viewmodel/presentationLogic.kt
+++ b/sample-viewmodel/src/main/java/com/example/molecule/viewmodel/presentationLogic.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.molecule.viewmodel
+
+import androidx.compose.runtime.Composable
+import kotlinx.coroutines.flow.Flow
+
+object Event
+object Model
+
+class RandomDogViewModel : MoleculeViewModel<Event, Model>() {
+  @Composable
+  override fun models(events: Flow<Event>): Model {
+    return RandomDogPresenter(events)
+  }
+}
+
+@Composable
+fun RandomDogPresenter(events: Flow<Event>): Model {
+  return Model
+}

--- a/sample-viewmodel/src/main/java/com/example/molecule/viewmodel/ui.kt
+++ b/sample-viewmodel/src/main/java/com/example/molecule/viewmodel/ui.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.molecule.viewmodel
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun RandomDogScreen(model: Model) {
+  Surface(modifier = Modifier.fillMaxSize()) {
+    Column {
+      Text("TODO: Build sample that hits https://dog.ceo/dog-api/")
+    }
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,6 +4,7 @@ include ':molecule-gradle-plugin'
 include ':molecule-runtime'
 
 include ':sample'
+include ':sample-viewmodel'
 
 enableFeaturePreview('TYPESAFE_PROJECT_ACCESSORS')
 


### PR DESCRIPTION
A common request I've heard from folks is an example of how to use Molecule to drive presentation logic when using androidx's `ViewModel`.

The plan here is to build a single screen sample app that hits [this API](https://dog.ceo/dog-api/) that displays random images of different dog breeds. I haven't actually implemented any of the actual logic yet, but that's not really the important part. What matters more is the skeleton proposed here.