### PR TITLE
Move Gradle wrapper validator action to own workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,8 +14,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: gradle/wrapper-validation-action@v1.0.5
-
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'

--- a/.github/workflows/gradle-wrapper.yaml
+++ b/.github/workflows/gradle-wrapper.yaml
@@ -1,0 +1,15 @@
+name: gradle-wrapper
+
+on:
+  pull_request:
+    paths:
+    - 'gradlew'
+    - 'gradlew.bat'
+    - 'gradle/wrapper/'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,8 +11,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: gradle/wrapper-validation-action@v1.0.5
-
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'


### PR DESCRIPTION
It fails too much and the wrapper almost never changes. New rule: Renovate is the only one who is allowed to bump Gradle (because we generally trust it) and this action will only run on those PRs.

Closes #155 