### PR TITLE
Switch to JB Compose compiler

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
 
 coil-compose = "io.coil-kt:coil-compose:2.2.2"
 
-compose-compiler = { module = "androidx.compose.compiler:compiler", version = "1.4.0" }
+compose-compiler = { module = "org.jetbrains.compose.compiler:compiler", version = "1.4.0" }
 compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version = "1.3.0" }
 compose-rx2 = { module = "androidx.compose.runtime:runtime-rxjava2", version = "1.3.3" }
 


### PR DESCRIPTION
Generally it is safer since they are the only ones actively supporting the targets we want.

Closes #178.