### PR TITLE
Fix typo in counter example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ val models: Flow<ProfileModel> = moleculeFlow(clock = Immediate) {
 And the counter example:
 ```kotlin
 fun counter(): Flow<Int> = moleculeFlow(clock = Immediate) {
-  val count by remember { mutableStateOf(0) }
+  var count by remember { mutableStateOf(0) }
 
   LaunchedEffect(Unit) {
     while (true) {


### PR DESCRIPTION
Replace `val` with `var` in the second counter example (it's correct in the first one).