### PR TITLE
Support custom version or coordinates for Compose compiler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,9 @@ subprojects {
       checkDependencies true
       checkReleaseBuilds false // Full lint runs as part of 'build' task.
     }
+    android.composeOptions {
+      kotlinCompilerExtensionVersion = libs.androidx.compose.compiler.get().version
+    }
   }
 
   apply plugin: 'com.diffplug.spotless'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ androidx-test-runner = { module = "androidx.test:runner", version = "1.5.2" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version = "1.7.2" }
 
 androidx-compose-bom = { module = "androidx.compose:compose-bom", version = "2023.06.01" }
+androidx-compose-compiler = "androidx.compose.compiler:compiler:1.5.1"
 androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
 
 coil-compose = "io.coil-kt:coil-compose:2.4.0"

--- a/molecule-gradle-plugin/build.gradle
+++ b/molecule-gradle-plugin/build.gradle
@@ -53,8 +53,6 @@ buildConfig {
   }
 
   packageName('app.cash.molecule.gradle')
-  buildConfigField("String", "composeCompilerGroupId", "\"${libs.jetbrains.compose.compiler.get().module.group}\"")
-  buildConfigField("String", "composeCompilerArtifactId", "\"${libs.jetbrains.compose.compiler.get().module.name}\"")
   buildConfigField("String", "composeCompilerVersion", "\"${libs.jetbrains.compose.compiler.get().version}\"")
   buildConfigField("String", "moleculeVersion", "\"${project.version}\"")
 }

--- a/molecule-gradle-plugin/src/main/java/app/cash/molecule/gradle/MoleculeExtension.kt
+++ b/molecule-gradle-plugin/src/main/java/app/cash/molecule/gradle/MoleculeExtension.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.molecule.gradle
+
+import org.gradle.api.provider.Property
+
+interface MoleculeExtension {
+  /**
+   * The version of the JetBrains Compose compiler to use, or a Maven coordinate triple of
+   * the custom Compose compiler to use.
+   *
+   * Example: using a custom version of the JetBrains Compose compiler
+   * ```kotlin
+   * redwood {
+   *   kotlinCompilerPlugin.set("1.4.8")
+   * }
+   * ```
+   *
+   * Example: using a custom Maven coordinate for the Compose compiler
+   * ```kotlin
+   * redwood {
+   *   kotlinCompilerPlugin.set("com.example:custom-compose-compiler:1.0.0")
+   * }
+   * ```
+   */
+  val kotlinCompilerPlugin: Property<String>
+}

--- a/molecule-gradle-plugin/src/test/fixtures/custom-compiler-coordinates/build.gradle
+++ b/molecule-gradle-plugin/src/test/fixtures/custom-compiler-coordinates/build.gradle
@@ -1,0 +1,30 @@
+buildscript {
+  dependencies {
+    classpath "app.cash.molecule:molecule-gradle-plugin:$moleculeVersion"
+    classpath libs.kotlin.plugin
+  }
+
+  repositories {
+    maven {
+      url "file://${rootDir.absolutePath}/../../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+  }
+}
+
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'app.cash.molecule'
+
+molecule {
+  // Use the AndroidX Compose compiler instead of JetBrains Compose compiler.
+  kotlinCompilerPlugin = libs.androidx.compose.compiler.get().toString()
+}
+
+repositories {
+  maven {
+    url "file://${rootDir.absolutePath}/../../../../../build/localMaven"
+  }
+  mavenCentral()
+  google()
+}

--- a/molecule-gradle-plugin/src/test/fixtures/custom-compiler-coordinates/settings.gradle
+++ b/molecule-gradle-plugin/src/test/fixtures/custom-compiler-coordinates/settings.gradle
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+  versionCatalogs {
+    libs {
+      from(files('../../../../../gradle/libs.versions.toml'))
+    }
+  }
+}

--- a/molecule-gradle-plugin/src/test/fixtures/custom-compiler-invalid/build.gradle
+++ b/molecule-gradle-plugin/src/test/fixtures/custom-compiler-invalid/build.gradle
@@ -1,0 +1,29 @@
+buildscript {
+  dependencies {
+    classpath "app.cash.molecule:molecule-gradle-plugin:$moleculeVersion"
+    classpath libs.kotlin.plugin
+  }
+
+  repositories {
+    maven {
+      url "file://${rootDir.absolutePath}/../../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+  }
+}
+
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'app.cash.molecule'
+
+molecule {
+  kotlinCompilerPlugin = 'wrong:format'
+}
+
+repositories {
+  maven {
+    url "file://${rootDir.absolutePath}/../../../../../build/localMaven"
+  }
+  mavenCentral()
+  google()
+}

--- a/molecule-gradle-plugin/src/test/fixtures/custom-compiler-invalid/settings.gradle
+++ b/molecule-gradle-plugin/src/test/fixtures/custom-compiler-invalid/settings.gradle
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+  versionCatalogs {
+    libs {
+      from(files('../../../../../gradle/libs.versions.toml'))
+    }
+  }
+}

--- a/molecule-gradle-plugin/src/test/fixtures/custom-compiler-version/build.gradle
+++ b/molecule-gradle-plugin/src/test/fixtures/custom-compiler-version/build.gradle
@@ -1,0 +1,36 @@
+buildscript {
+  ext.kotlinVersion = '1.8.20'
+
+  dependencies {
+    classpath "app.cash.molecule:molecule-gradle-plugin:$moleculeVersion"
+    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+  }
+
+  repositories {
+    maven {
+      url "file://${rootDir.absolutePath}/../../../../../build/localMaven"
+    }
+    mavenCentral()
+    google()
+  }
+}
+
+if (kotlinVersion == libs.kotlin.plugin.get().version) {
+  throw RuntimeException("This test requires a different version of Kotlin then the Molecule build")
+}
+
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'app.cash.molecule'
+
+molecule {
+  // Use the JetBrains Compose compiler version for the version of Kotlin used by this project.
+  kotlinCompilerPlugin = '1.4.8'
+}
+
+repositories {
+  maven {
+    url "file://${rootDir.absolutePath}/../../../../../build/localMaven"
+  }
+  mavenCentral()
+  google()
+}

--- a/molecule-gradle-plugin/src/test/fixtures/custom-compiler-version/settings.gradle
+++ b/molecule-gradle-plugin/src/test/fixtures/custom-compiler-version/settings.gradle
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+  versionCatalogs {
+    libs {
+      from(files('../../../../../gradle/libs.versions.toml'))
+    }
+  }
+}

--- a/molecule-gradle-plugin/src/test/java/app/cash/molecule/gradle/MoleculePluginTest.kt
+++ b/molecule-gradle-plugin/src/test/java/app/cash/molecule/gradle/MoleculePluginTest.kt
@@ -38,6 +38,25 @@ class MoleculePluginTest {
     )
   }
 
+  @Test fun customCompilerCoordinates() {
+    createRunner("custom-compiler-coordinates").build()
+  }
+
+  @Test fun customCompilerInvalid() {
+    val result = createRunner("custom-compiler-invalid").buildAndFail()
+    assertThat(result.output).contains(
+      """
+      |Illegal format of 'molecule.kotlinCompilerPlugin' property.
+      |Expected format: either '<VERSION>' or '<GROUP_ID>:<ARTIFACT_ID>:<VERSION>'
+      |Actual value: 'wrong:format'
+      """.trimMargin(),
+    )
+  }
+
+  @Test fun customCompilerVersion() {
+    createRunner("custom-compiler-version").build()
+  }
+
   private fun createRunner(fixture: String): GradleRunner {
     val fixtureDir = File("src/test/fixtures", fixture)
     val gradleRoot = File(fixtureDir, "gradle").also { it.mkdir() }


### PR DESCRIPTION
Since this project does not build a Kotlin compiler plugin, we should not be forced to do a release for new versions of Kotlin. This property will allow consumers to upgrade thier Kotlin version by specifying a newer JetBrains Compose compiler version, or a totally different set of Maven coordiantes for a custom Compose compiler aritfact.

Closes #282 