### PR TITLE
Add APIs with exposed emitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## [Unreleased]
 
 
+## [1.2.0]
+
+- Add APIs with exposed emitter.
+
+
 ## [1.1.0] - 2023-07-20
 
 New:


### PR DESCRIPTION
## Problem:
We are use existing infrastructure of `rememberSaveable` to persist values in presenter, it requires to provide `SaveableStateRegistry` via `CompositionLocalProvider`. Current molecule API only takes composable body which return state. This API is not convenient for our use case.  `CompositionLocalProvider` can't be used because it do not return value from it's content lambda.
```kotlin
body = {
    CompositionLocalProvider(
        LocalSaveableStateRegistry provides saveableStateRegistry,
    ) {
        presenterComposable() // <- CLP do not return this value
    }
}
```
Now we use own implementation of CLP that can return value from content lambda:
```kotlin
@Composable
@OptIn(InternalComposeApi::class)
private inline fun withPresenterSaveableStateRegistry(
    content: @Composable () -> State,
): State {
    currentComposer.startProviders(
        values = arrayOf(LocalSaveableStateRegistry provides saveableStateRegistry),
    )
    val state = content()
    currentComposer.endProviders()
    return state
}
```
But this approach has at least two significant disadvantages:
1. We use internal compose API, that can change at every moment.
2. Our CLP recomposes at every composition.

## Proposal:
Molecule need alternative API with exposed emitter to be able to handle such cases:
```kotlin
body = { emitter ->
    CompositionLocalProvider(
        LocalSaveableStateRegistry provides saveableStateRegistry,
    ) {
        emitter(presenterComposable())
    }
}
```

Dunno is it possible to leave trailing lambda syntax for both bodies (with and w/o emitter). This head-on implementation has declaration clash when using trailing lambda. It requires to specify body parameter name to give a hint for compiler which lambda you want to use. Maybe it's possible to do this better, so this is not final code to approve.