### PR TITLE
Renovate: Use stable Ktlint coordinates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -17,7 +17,7 @@
       "groupName": "Spotless/ktlint",
       "matchPackagePrefixes": [
         "com.diffplug.spotless",
-        "com.pinterest:ktlint",
+        "com.pinterest.ktlint",
       ],
     },
   ],


### PR DESCRIPTION
Ktlint did change their group name since 1.0.0