### PR TITLE
Crossinline all the lambdas that reasonably can be.

### DIFF
--- a/molecule-runtime/src/commonMain/kotlin/app/cash/molecule/GatedFrameClock.kt
+++ b/molecule-runtime/src/commonMain/kotlin/app/cash/molecule/GatedFrameClock.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.launch
  * While running, any request for a frame immediately succeeds. If stopped, requests for a frame wait until
  * the clock is set to run again.
  */
+@PublishedApi
 internal class GatedFrameClock(scope: CoroutineScope) : MonotonicFrameClock {
   private val frameSends = Channel<Unit>(CONFLATED)
 


### PR DESCRIPTION
This is a very minor change. I understand that exposing all these functions in ABI might not be reasonable. If so, ignore this PR.