### PR TITLE
Test tweaks

### DIFF
--- a/molecule-runtime/src/commonTest/kotlin/app/cash/molecule/MoleculeStateFlowTest.kt
+++ b/molecule-runtime/src/commonTest/kotlin/app/cash/molecule/MoleculeStateFlowTest.kt
@@ -28,9 +28,7 @@ import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isSameInstanceAs
-import kotlin.coroutines.CoroutineContext
 import kotlin.test.Test
-import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -101,15 +99,6 @@ class MoleculeStateFlowTest {
     }.isSameInstanceAs(runtimeException)
 
     scope.cancel()
-  }
-
-  class RecordingExceptionHandler : CoroutineExceptionHandler {
-    private val _exceptions = mutableListOf<Throwable>()
-    val exceptions get() = _exceptions
-    override fun handleException(context: CoroutineContext, exception: Throwable) {
-      _exceptions += exception
-    }
-    override val key get() = CoroutineExceptionHandler
   }
 
   @Test fun errorDelayed() = runTest {

--- a/molecule-runtime/src/commonTest/kotlin/app/cash/molecule/MoleculeTest.kt
+++ b/molecule-runtime/src/commonTest/kotlin/app/cash/molecule/MoleculeTest.kt
@@ -35,10 +35,8 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotSameInstanceAs
 import assertk.assertions.isSameInstanceAs
-import kotlin.coroutines.CoroutineContext
 import kotlin.test.Test
 import kotlin.test.fail
-import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -110,15 +108,6 @@ class MoleculeTest {
     }.isSameInstanceAs(runtimeException)
 
     scope.cancel()
-  }
-
-  class RecordingExceptionHandler : CoroutineExceptionHandler {
-    private val _exceptions = mutableListOf<Throwable>()
-    val exceptions get() = _exceptions
-    override fun handleException(context: CoroutineContext, exception: Throwable) {
-      _exceptions += exception
-    }
-    override val key get() = CoroutineExceptionHandler
   }
 
   @Test fun errorDelayed() = runTest {
@@ -310,7 +299,7 @@ class MoleculeTest {
     val runtimeException = object : RuntimeException() {}
     var count by mutableStateOf(0)
     launch {
-      val exception = kotlin.runCatching {
+      val exception = runCatching {
         moleculeFlow(mode = Immediate) {
           if (count == 1) {
             throw runtimeException
@@ -336,7 +325,7 @@ class MoleculeTest {
     // Use a custom subtype to prevent coroutines from breaking referential equality.
     val runtimeException = object : RuntimeException() {}
     launch {
-      val exception = kotlin.runCatching {
+      val exception = runCatching {
         moleculeFlow(mode = Immediate) {
           LaunchedEffect(Unit) {
             delay(50)

--- a/molecule-runtime/src/commonTest/kotlin/app/cash/molecule/RecordingExceptionHandler.kt
+++ b/molecule-runtime/src/commonTest/kotlin/app/cash/molecule/RecordingExceptionHandler.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.molecule
+
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineExceptionHandler
+
+class RecordingExceptionHandler : CoroutineExceptionHandler {
+  val exceptions = mutableListOf<Throwable>()
+
+  override fun handleException(context: CoroutineContext, exception: Throwable) {
+    exceptions += exception
+  }
+
+  override val key get() = CoroutineExceptionHandler
+}


### PR DESCRIPTION
- Share a the recording exception handler.
- Don't use a pointless backing property when the mutable type is exposed.
- Remove redundant package qualifier on runCatching.