### PR TITLE
Remove explicit JS IR opt-in property

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -35,7 +35,6 @@ android.defaults.buildfeatures.shaders=false
 # Signals to our own plugin that we are building within the repo.
 app.cash.molecule.internal=true
 
-kotlin.js.compiler=ir
 kotlin.mpp.stability.nowarn=true
 
 # This is needed for the JB Compose runtime to link on native targets. They also use this flag


### PR DESCRIPTION
It is the default now

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
