### PR TITLE
Fix sample-viewmodel running

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ buildscript {
     classpath libs.android.plugin
     classpath libs.kotlin.plugin.core
     classpath libs.kotlin.plugin.compose
+    classpath libs.kotlin.ksp.plugin
     classpath libs.maven.publish.plugin
     classpath libs.dokka.plugin
     classpath libs.spotless.plugin

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ junit = { module = "junit:junit", version = "4.13.2" }
 kotlin-plugin-core = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-plugin-compose = { module = "org.jetbrains.kotlin:compose-compiler-gradle-plugin", version.ref = "kotlin" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+kotlin-ksp-plugin = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin:2.0.0-1.0.21"
 
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutine" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutine" }
@@ -47,6 +48,7 @@ squareup-okhttp-logging-interceptor = { module = "com.squareup.okhttp3:logging-i
 squareup-retrofit-client = { module = "com.squareup.retrofit2:retrofit", version.ref = "squareup-retrofit" }
 squareup-retrofit-converter-scalars = { module = "com.squareup.retrofit2:converter-scalars", version.ref = "squareup-retrofit" }
 squareup-retrofit-converter-moshi = { module = "com.squareup.retrofit2:converter-moshi", version.ref = "squareup-retrofit" }
+squareup-moshi-codegen = "com.squareup.moshi:moshi-kotlin-codegen:1.15.1"
 
 assertk = "com.willowtreeapps.assertk:assertk:0.28.1"
 turbine = { module = "app.cash.turbine:turbine", version = "1.1.0" }

--- a/renovate.json5
+++ b/renovate.json5
@@ -6,10 +6,11 @@
   "packageRules": [
     {
       // Compose compiler is tightly coupled to Kotlin version.
-      "groupName": "Kotlin/Compose",
+      "groupName": "Kotlin/KSP/Compose",
       "matchPackagePrefixes": [
         "org.jetbrains.compose.compiler",
         "org.jetbrains.kotlin:kotlin",
+        "com.google.devtools.ksp",
       ],
     },
   ],

--- a/sample-viewmodel/build.gradle
+++ b/sample-viewmodel/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.application'
 apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: 'org.jetbrains.kotlin.plugin.compose'
+apply plugin: 'com.google.devtools.ksp'
 
 dependencies {
   implementation projects.moleculeRuntime
@@ -10,6 +11,8 @@ dependencies {
   implementation libs.coil.compose
   implementation libs.squareup.retrofit.client
   implementation libs.squareup.retrofit.converter.moshi
+
+  ksp libs.squareup.moshi.codegen
 
   testImplementation libs.junit
   testImplementation libs.kotlinx.coroutines.test

--- a/sample-viewmodel/src/main/java/com/example/molecule/viewmodel/data.kt
+++ b/sample-viewmodel/src/main/java/com/example/molecule/viewmodel/data.kt
@@ -15,6 +15,7 @@
  */
 package com.example.molecule.viewmodel
 
+import com.squareup.moshi.JsonClass
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 import retrofit2.create
@@ -50,13 +51,16 @@ fun PupperPicsService(): PupperPicsService {
   }
 }
 
-private interface PupperPicsApi {
+interface PupperPicsApi {
   @GET("breeds/list/all")
   suspend fun listBreeds(): ListResponse
 
   @GET("breed/{breed}/images/random")
   suspend fun randomImageFor(@Path("breed", encoded = true) breed: String): ImageResponse
 
+  @JsonClass(generateAdapter = true)
   data class ListResponse(val message: Map<String, List<String>>)
+
+  @JsonClass(generateAdapter = true)
   data class ImageResponse(val message: String)
 }


### PR DESCRIPTION
```
Caused by: java.lang.IllegalArgumentException: Cannot serialize Kotlin type com.example.molecule.viewmodel.PupperPicsApi$ListResponse.
Reflective serialization of Kotlin classes without using kotlin-reflect has undefined and unexpected behavior.
Please use KotlinJsonAdapterFactory from the moshi-kotlin artifact or use code gen from the moshi-kotlin-codegen artifact.
  at com.squareup.moshi.ClassJsonAdapter$1.create(ClassJsonAdapter.java:98)
  at com.squareup.moshi.Moshi.adapter(Moshi.java:146)
  at com.squareup.moshi.Moshi.adapter(Moshi.java:106)
```

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
