### PR TITLE
Prepare for 2.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
           distribution: 'zulu'
           java-version: 20
       - uses: gradle/actions/setup-gradle@v3
-      - run: ./gradlew build assembleAndroidTest dokkaHtmlMultiModule
+      - run: ./gradlew build assembleAndroidTest dokkaHtml
 
       - name: Run Tests
         uses: reactivecircus/android-emulator-runner@v2
@@ -47,6 +47,6 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: site
-          FOLDER: build/dokka/htmlMultiModule
+          FOLDER: molecule-runtime/build/dokka/html
           TARGET_FOLDER: docs/latest/
           CLEAN: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
           distribution: 'zulu'
           java-version: 20
       - uses: gradle/actions/setup-gradle@v3
-      - run: ./gradlew publish dokkaHtmlMultiModule
+      - run: ./gradlew publish dokkaHtml
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
@@ -38,6 +38,6 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: site
-          FOLDER: build/dokka/htmlMultiModule
-          TARGET_FOLDER: docs/1.x/
+          FOLDER: molecule-runtime/build/dokka/html
+          TARGET_FOLDER: docs/2.x/
           CLEAN: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,77 @@
 ## [Unreleased]
 
 New:
-- Nothing yet!
+- Support for Kotlin 2.0.0!
 
 Changed:
-- Nothing yet!
+- Remove our Gradle plugin in favor of JetBrains' (see below for more).
 
 Fixed:
-- Nothing yet!
+- Mac OS `DisplayLinkClock` was updated to correctly use a "static" function for pointer-passing to `CVDisplayLink`, as newly-enforced by Kotlin 2.0. This should not cause a behavior change.
+
+
+### Gradle plugin removed
+
+This version of Molecule removes the custom Gradle plugin in favor of [the official JetBrains Compose compiler plugin](https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-compiler.html) which ships as part of Kotlin itself.
+Each module in which you had previously applied the `app.cash.molecule` plugin should be changed to apply `org.jetbrains.kotlin.plugin.compose` instead.
+The Molecule runtime will no longer be added as a result of the plugin change, and so any module which references Molecule APIs like `launchMolecule` should apply the `app.cash.molecule:molecule-runtime` dependency.
+
+For posterity, the Kotlin version compatibility table and compiler version customization for our old Molecule Gradle plugin will be archived here:
+
+<details>
+<summary>Molecule 1.x Gradle plugin Kotlin compatibility table</summary>
+<p>
+
+Since Kotlin compiler plugins are an unstable API, certain versions of Molecule only work with
+certain versions of Kotlin.
+
+| Kotlin | Molecule       |
+|--------|----------------|
+| 1.9.24 | 1.4.3          |
+| 1.9.23 | 1.4.2          |
+| 1.9.22 | 1.3.2 - 1.4.1  |
+| 1.9.21 | 1.3.1          |
+| 1.9.20 | 1.3.0          |
+| 1.9.10 | 1.2.1          |
+| 1.9.0  | 1.1.0 - 1.2.0  |
+| 1.8.22 | 0.11.0 - 1.0.0 |
+| 1.8.21 | 0.10.0         |
+| 1.8.20 | 0.9.0          |
+| 1.8.10 | 0.8.0          |
+| 1.8.0  | 0.7.0 - 0.7.1  |
+| 1.7.20 | 0.6.0 - 0.6.1  |
+| 1.7.10 | 0.4.0 - 0.5.0  |
+| 1.7.0  | 0.3.0 - 0.3.1  |
+| 1.6.10 | 0.2.0          |
+| 1.5.31 | 0.1.0          |
+
+</p>
+</details>
+
+<details>
+<summary>Molecule 1.x Gradle plugin Compose compiler customization instructions</summary>
+<p>
+
+Each version of Molecule ships with a specific JetBrains Compose compiler version which works with
+a single version of Kotlin (see version table above). Newer versions of the Compose
+compiler or alternate Compose compilers can be specified using the Gradle extension.
+
+To use a new version of the JetBrains Compose compiler version:
+```kotlin
+molecule {
+  kotlinCompilerPlugin.set("1.4.8")
+}
+```
+
+To use an alternate Compose compiler dependency:
+```kotlin
+molecule {
+  kotlinCompilerPlugin.set("com.example:custom-compose-compiler:1.0.0")
+}
+```
+
+</p>
+</details>
 
 
 ## [1.4.3] - 2024-05-15

--- a/README.md
+++ b/README.md
@@ -163,62 +163,33 @@ For more information see [the `moleculeFlow` documentation](https://cashapp.gith
 
 ## Usage
 
-Add the buildscript dependency and apply the plugin to every module which wants to call `launchMolecule` or define `@Composable` functions for use with Molecule.
+Molecule is a library for Compose, and it relies on JetBrains' Kotlin Compose plugin to be present for use.
+Any module which wants to call `launchMolecule` or define `@Composable` functions for use with Molecule must have this plugin applied.
+For more information, see [the JetBrains Compose compiler documentation](https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-compiler.html).
+
+Molecule itself can then be added like any other dependency:
 
 ```groovy
-buildscript {
-  repositories {
-    mavenCentral()
-  }
-  dependencies {
-    classpath 'app.cash.molecule:molecule-gradle-plugin:1.4.3'
-  }
+dependencies {
+  implementation("app.cash.molecule:molecule-runtime:2.0.0")
 }
-
-apply plugin: 'app.cash.molecule'
 ```
-
-Since Kotlin compiler plugins are an unstable API, certain versions of Molecule only work with
-certain versions of Kotlin.
-
-| Kotlin | Molecule       |
-|--------|----------------|
-| 1.9.24 | 1.4.3          |
-| 1.9.23 | 1.4.2          |
-| 1.9.22 | 1.3.2 - 1.4.1  |
-| 1.9.21 | 1.3.1          |
-| 1.9.20 | 1.3.0          |
-| 1.9.10 | 1.2.1          |
-| 1.9.0  | 1.1.0 - 1.2.0  |
-| 1.8.22 | 0.11.0 - 1.0.0 |
-| 1.8.21 | 0.10.0         |
-| 1.8.20 | 0.9.0          |
-| 1.8.10 | 0.8.0          |
-| 1.8.0  | 0.7.0 - 0.7.1  |
-| 1.7.20 | 0.6.0 - 0.6.1  |
-| 1.7.10 | 0.4.0 - 0.5.0  |
-| 1.7.0  | 0.3.0 - 0.3.1  |
-| 1.6.10 | 0.2.0          |
-| 1.5.31 | 0.1.0          |
 
 <details>
 <summary>Snapshots of the development version are available in Sonatype's snapshots repository.</summary>
 <p>
 
 ```groovy
-buildscript {
-  repositories {
-    mavenCentral()
-    maven {
-      url 'https://oss.sonatype.org/content/repositories/snapshots/'
-    }
-  }
-  dependencies {
-    classpath 'app.cash.molecule:molecule-gradle-plugin:1.5.0-SNAPSHOT'
+repositories {
+  mavenCentral()
+  maven {
+    url "https://oss.sonatype.org/content/repositories/snapshots/"
   }
 }
 
-apply plugin: 'app.cash.molecule'
+dependencies {
+  implementation("app.cash.molecule:molecule-runtime:2.1.0-SNAPSHOT")
+}
 ```
 
 </p>
@@ -273,26 +244,6 @@ android {
     unitTests.returnDefaultValues = true
   }
   ...
-}
-```
-
-### Custom Compose Compiler
-
-Each version of Molecule ships with a specific JetBrains Compose compiler version which works with
-a single version of Kotlin (see [version table](#usage) above). Newer versions of the Compose
-compiler or alternate Compose compilers can be specified using the Gradle extension.
-
-To use a new version of the JetBrains Compose compiler version:
-```kotlin
-molecule {
-  kotlinCompilerPlugin.set("1.4.8")
-}
-```
-
-To use an alternate Compose compiler dependency:
-```kotlin
-molecule {
-  kotlinCompilerPlugin.set("com.example:custom-compose-compiler:1.0.0")
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,6 @@ buildscript {
   }
 }
 
-apply plugin: 'org.jetbrains.dokka'
-
 allprojects {
   version = property("VERSION_NAME") as String
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 GROUP=app.cash.molecule
 
 # HEY! If you change the major version here be sure to update release.yaml doc target folder!
-VERSION_NAME=1.5.0-SNAPSHOT
+VERSION_NAME=2.0.0-SNAPSHOT
 
 SONATYPE_AUTOMATIC_RELEASE=true
 SONATYPE_HOST=DEFAULT


### PR DESCRIPTION
Closes #278.
Closes #286.
Closes #287.
Closes #308.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
