### PR TITLE
Do not declare the Compose compiler version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,9 +62,6 @@ subprojects {
       checkDependencies true
       checkReleaseBuilds false // Full lint runs as part of 'build' task.
     }
-    android.composeOptions {
-      kotlinCompilerExtensionVersion = libs.androidx.compose.compiler.get().version
-    }
   }
 
   apply plugin: 'com.diffplug.spotless'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,6 @@ androidx-test-runner = { module = "androidx.test:runner", version = "1.6.1" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version = "1.9.1" }
 
 androidx-compose-bom = { module = "androidx.compose:compose-bom", version = "2024.06.00" }
-androidx-compose-compiler = "androidx.compose.compiler:compiler:1.5.14"
 androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
 
 coil-compose = "io.coil-kt:coil-compose:2.7.0"


### PR DESCRIPTION
We get it from Kotlin version and plugin now.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
