### PR TITLE
Add support for suspending observation of flows/state observation while the UI is inactive.

### DIFF
--- a/molecule-runtime/src/commonMain/kotlin/app/cash/molecule/molecule.kt
+++ b/molecule-runtime/src/commonMain/kotlin/app/cash/molecule/molecule.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 
@@ -121,15 +122,20 @@ public fun <T> CoroutineScope.launchMolecule(
 ): StateFlow<T> {
   var flow: MutableStateFlow<T>? = null
 
+  val isActiveFlow = MutableStateFlow(false)
+
   launchMolecule(
     context = context,
     mode = mode,
+    isActiveFlow = isActiveFlow,
     emitter = { value ->
       val outputFlow = flow
       if (outputFlow != null) {
         outputFlow.value = value
       } else {
-        flow = MutableStateFlow(value)
+        flow = MutableStateFlow(value).also { flow ->
+          launch { flow.subscriptionCount.collectLatest { isActiveFlow.value = it > 0 } }
+        }
       }
     },
     body = body,
@@ -161,18 +167,26 @@ public fun <T> CoroutineScope.launchMolecule(
  *
  * The coroutine context is inherited from the [CoroutineScope].
  * Additional context elements can be specified with [context] argument.
+ *
+ * @param isActiveFlow if this flow is present, flows and coroutines within the composition
+ * may be paused when it is false. See [collectAsStateWhileMoleculeActive],
+ * [repeatWhileMoleculeActive], [awaitMoleculeActive].
  */
 public fun <T> CoroutineScope.launchMolecule(
   mode: RecompositionMode,
   emitter: (value: T) -> Unit,
   context: CoroutineContext = EmptyCoroutineContext,
+  isActiveFlow: StateFlow<Boolean>? = null,
   body: @Composable () -> T,
 ) {
   val clockContext = when (mode) {
     RecompositionMode.ContextClock -> EmptyCoroutineContext
     RecompositionMode.Immediate -> GatedFrameClock(this)
   }
-  val finalContext = coroutineContext + context + clockContext
+
+  val finalContext = coroutineContext + context + clockContext + MoleculeActiveContextElement(
+    isActiveFlow ?: MutableStateFlow(true),
+  )
 
   val recomposer = Recomposer(finalContext)
   val composition = Composition(UnitApplier, recomposer)

--- a/molecule-runtime/src/commonMain/kotlin/app/cash/molecule/moleculeActive.kt
+++ b/molecule-runtime/src/commonMain/kotlin/app/cash/molecule/moleculeActive.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.molecule
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.first
+
+internal class MoleculeActiveContextElement(
+  val isMoleculeActive: StateFlow<Boolean>,
+) : AbstractCoroutineContextElement(Key) {
+  companion object Key : CoroutineContext.Key<MoleculeActiveContextElement>
+}
+
+private val CoroutineScope.moleculeActiveFlow
+  get() = coroutineContext.moleculeActiveFlow
+
+private val CoroutineContext.moleculeActiveFlow
+  get() = this[MoleculeActiveContextElement]?.isMoleculeActive
+    ?: error("No Molecule context element found")
+
+/**
+ * Collects the specified flow as state, but only while the Molecule is active.
+ */
+@Composable
+public fun <T> StateFlow<T>.collectAsStateWhileMoleculeActive(): State<T> =
+  collectAsStateWhileMoleculeActive(this.value)
+
+/**
+ * Collects the specified flow as state, but only while the Molecule is active.
+ *
+ * @param initialValue the initial value to use as state.
+ */
+@Composable
+public fun <T> Flow<T>.collectAsStateWhileMoleculeActive(initialValue: T): State<T> {
+  val originalFlow = this
+  val state = remember { mutableStateOf(initialValue) }
+  LaunchedEffect(Unit) {
+    repeatWhileMoleculeActive { originalFlow.collect { state.value = it } }
+  }
+  return state
+}
+
+/**
+ * Runs the specified suspend block every time the molecule is active, cancelling it when the
+ * molecule becomes inactive.
+ */
+public suspend fun CoroutineScope.repeatWhileMoleculeActive(block: suspend () -> Unit) {
+  moleculeActiveFlow.collectLatest { isActive ->
+    if (!isActive) return@collectLatest
+    block()
+  }
+}
+
+/**
+ * Suspends until the Molecule is active.
+ */
+public suspend fun CoroutineScope.awaitMoleculeActive() {
+  moleculeActiveFlow.first { it }
+}

--- a/molecule-runtime/src/commonTest/kotlin/app/cash/molecule/MoleculeActiveTest.kt
+++ b/molecule-runtime/src/commonTest/kotlin/app/cash/molecule/MoleculeActiveTest.kt
@@ -1,0 +1,246 @@
+package app.cash.molecule
+
+import androidx.compose.runtime.LaunchedEffect
+import app.cash.molecule.RecompositionMode.Immediate
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import kotlin.test.Test
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.plus
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MoleculeActiveTest {
+
+  @Test
+  fun moleculeInactive_flowCold() = runTest {
+    cancelWhenDone {
+      val flow = flow { emit(1) }
+
+      val stateFlow = launchMolecule(Immediate) {
+        flow.collectAsStateWhileMoleculeActive(0).value
+      }
+
+      runCurrent()
+      assertThat(stateFlow.value).isEqualTo(0)
+    }
+  }
+
+  @Test
+  fun moleculeActive_flowHot() = runTest {
+    cancelWhenDone {
+      val flow = flow { emit(1) }
+
+      val stateFlow = launchMolecule(Immediate) {
+        flow.collectAsStateWhileMoleculeActive(0).value
+      }
+
+      launch { stateFlow.collect { } }
+
+      runCurrent()
+      assertThat(stateFlow.value).isEqualTo(1)
+    }
+  }
+
+
+  @Test
+  fun moleculeActiveThenInactive_flowCold() = runTest {
+    cancelWhenDone {
+      val flow = flow {
+        emit(1)
+        delay(1)
+        emit(2)
+      }
+
+      val stateFlow = launchMolecule(Immediate) {
+        flow.collectAsStateWhileMoleculeActive(0).value
+      }
+
+      val collectJob = launch { stateFlow.collect { } }
+
+      runCurrent()
+      collectJob.cancel()
+
+      advanceTimeBy(1)
+      runCurrent()
+      assertThat(stateFlow.value).isEqualTo(1)
+    }
+  }
+
+
+  @Test
+  fun moleculeInactive_stateFlowCold() = runTest {
+    cancelWhenDone {
+      val flow = flow { emit(1) }.stateIn(this, SharingStarted.WhileSubscribed(), 0)
+
+      val stateFlow = launchMolecule(Immediate) {
+        flow.collectAsStateWhileMoleculeActive().value
+      }
+
+      runCurrent()
+      assertThat(stateFlow.value).isEqualTo(0)
+    }
+  }
+
+  @Test
+  fun moleculeActive_stateFlowHot() = runTest {
+    cancelWhenDone {
+      val flow = flow { emit(1) }.stateIn(this, SharingStarted.WhileSubscribed(), 0)
+
+      val stateFlow = launchMolecule(Immediate) {
+        flow.collectAsStateWhileMoleculeActive().value
+      }
+
+      launch { stateFlow.collect { } }
+
+      runCurrent()
+      assertThat(stateFlow.value).isEqualTo(1)
+    }
+  }
+
+
+  @Test
+  fun moleculeActiveThenInactive_stateFlowCold() = runTest {
+    cancelWhenDone {
+      val flow = flow {
+        emit(1)
+        delay(1)
+        emit(2)
+      }.stateIn(this, SharingStarted.WhileSubscribed(), 0)
+
+      val stateFlow = launchMolecule(Immediate) {
+        flow.collectAsStateWhileMoleculeActive().value
+      }
+
+      val collectJob = launch { stateFlow.collect { } }
+
+      runCurrent()
+      collectJob.cancel()
+
+      advanceTimeBy(1)
+      runCurrent()
+      assertThat(stateFlow.value).isEqualTo(1)
+    }
+  }
+
+  @Test
+  fun moleculeInactive_coroutineDoesNotRun() = runTest {
+    cancelWhenDone {
+      var coroutineRan = false
+      val stateFlow = launchMolecule(Immediate) {
+        LaunchedEffect(Unit) {
+          repeatWhileMoleculeActive {
+            coroutineRan = true
+          }
+        }
+      }
+
+      runCurrent()
+
+      assertThat(coroutineRan).isEqualTo(false)
+    }
+  }
+
+  @Test
+  fun moleculeActive_coroutineRuns() = runTest {
+    cancelWhenDone {
+      var coroutineRan = false
+      val stateFlow = launchMolecule(Immediate) {
+        LaunchedEffect(Unit) {
+          repeatWhileMoleculeActive {
+            coroutineRan = true
+          }
+        }
+      }
+
+      launch { stateFlow.collect {} }
+      runCurrent()
+
+      assertThat(coroutineRan).isEqualTo(true)
+    }
+  }
+
+  @Test
+  fun moleculeActiveInactiveThenActive_coroutineRestarted() = runTest {
+    cancelWhenDone {
+      var coroutineRunCount = 0
+      val stateFlow = launchMolecule(Immediate) {
+        LaunchedEffect(Unit) {
+          repeatWhileMoleculeActive {
+            while (true) {
+              delay(1)
+              coroutineRunCount++
+            }
+          }
+        }
+      }
+
+      val firstCollector = launch { stateFlow.collect {} }
+      advanceTimeBy(1)
+      runCurrent()
+      assertThat(coroutineRunCount).isEqualTo(1)
+
+      firstCollector.cancel()
+      advanceTimeBy(1)
+      runCurrent()
+      assertThat(coroutineRunCount).isEqualTo(1)
+
+      launch { stateFlow.collect {} }
+      advanceTimeBy(1)
+      runCurrent()
+      assertThat(coroutineRunCount).isEqualTo(2)
+    }
+  }
+
+  @Test
+  fun moleculeInactive_suspends() = runTest {
+    cancelWhenDone {
+      var ran = false
+      val stateFlow = launchMolecule(Immediate) {
+        LaunchedEffect(Unit) {
+          awaitMoleculeActive()
+          ran = true
+        }
+      }
+
+      runCurrent()
+      assertThat(ran).isFalse()
+    }
+  }
+
+  @Test
+  fun moleculeActive_doesNotSuspend() = runTest {
+    cancelWhenDone {
+      var ran = false
+      val stateFlow = launchMolecule(Immediate) {
+        LaunchedEffect(Unit) {
+          awaitMoleculeActive()
+          ran = true
+        }
+      }
+
+      launch { stateFlow.collect {} }
+      runCurrent()
+      assertThat(ran).isTrue()
+    }
+  }
+
+  private suspend fun CoroutineScope.cancelWhenDone(block: suspend CoroutineScope.() -> Unit) {
+    val job = Job(coroutineContext.job)
+    val scope = this + job
+    block(scope)
+    job.cancel()
+  }
+}


### PR DESCRIPTION
This change:
 - Adds a coroutine context element wrapping a stateflow representing whether the molecule is being observed or not. This, for most apps that collect the state via .collectAsStateWithLifecycle, corresponds to whether the UI is active.
 - Add an extension function CoroutineScope.repeatWhileMoleculeActive, which runs and cancels the inner block as the molecule becomes active and inactive, analogous to androidx.lifecycle.repeatOnLifecycle.
 - Add extension functions on Flow and StateFlow to collectAsStateWhileMoleculeActive, attaching and detaching collectors as the molecule becomes and unbecomes active. This pauses production in Flows and in StateFlows that produce .WhileSubscribed().
 - Also adds an optional `composeOnlyWhileSubscribed` option to `launchMolecule` which pauses the entire state production while there are no subscribers. I am actually not sure this is necessary anymore with the other 3 changes, and on its own is not really sufficient to avoid extraneous state production, so I am wondering if we should just remove it.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
