### PR TITLE
MoleculeTest.errorInEmitterDelayed flaky

### DIFF
--- a/molecule-runtime/src/commonTest/kotlin/app/cash/molecule/MoleculeStateFlowTest.kt
+++ b/molecule-runtime/src/commonTest/kotlin/app/cash/molecule/MoleculeStateFlowTest.kt
@@ -33,14 +33,13 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.supervisorScope
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
@@ -87,9 +86,10 @@ class MoleculeStateFlowTest {
     job.cancel()
   }
 
-  @Test fun errorImmediately() {
+  @Test fun errorImmediately() = runTest {
+    val job = Job()
     val clock = BroadcastFrameClock()
-    val scope = CoroutineScope(UnconfinedTestDispatcher() + clock)
+    val scope = CoroutineScope(coroutineContext + job + clock)
 
     // Use a custom subtype to prevent coroutines from breaking referential equality.
     val runtimeException = object : RuntimeException() {}
@@ -99,7 +99,7 @@ class MoleculeStateFlowTest {
       }
     }.isSameInstanceAs(runtimeException)
 
-    scope.cancel()
+    job.cancelAndJoin()
   }
 
   @Test fun errorDelayed() = runTest {

--- a/molecule-runtime/src/commonTest/kotlin/app/cash/molecule/MoleculeStateFlowTest.kt
+++ b/molecule-runtime/src/commonTest/kotlin/app/cash/molecule/MoleculeStateFlowTest.kt
@@ -40,6 +40,7 @@ import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
@@ -88,7 +89,7 @@ class MoleculeStateFlowTest {
 
   @Test fun errorImmediately() {
     val clock = BroadcastFrameClock()
-    val scope = CoroutineScope(clock)
+    val scope = CoroutineScope(UnconfinedTestDispatcher() + clock)
 
     // Use a custom subtype to prevent coroutines from breaking referential equality.
     val runtimeException = object : RuntimeException() {}

--- a/molecule-runtime/src/commonTest/kotlin/app/cash/molecule/MoleculeTest.kt
+++ b/molecule-runtime/src/commonTest/kotlin/app/cash/molecule/MoleculeTest.kt
@@ -41,13 +41,11 @@ import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
@@ -96,9 +94,10 @@ class MoleculeTest {
     job.cancel()
   }
 
-  @Test fun errorImmediately() {
+  @Test fun errorImmediately() = runTest {
+    val job = Job()
     val clock = BroadcastFrameClock()
-    val scope = CoroutineScope(UnconfinedTestDispatcher() + clock)
+    val scope = CoroutineScope(coroutineContext + job + clock)
 
     // Use a custom subtype to prevent coroutines from breaking referential equality.
     val runtimeException = object : RuntimeException() {}
@@ -108,7 +107,7 @@ class MoleculeTest {
       }
     }.isSameInstanceAs(runtimeException)
 
-    scope.cancel()
+    job.cancelAndJoin()
   }
 
   @Test fun errorDelayed() = runTest {
@@ -167,9 +166,10 @@ class MoleculeTest {
     job.cancel()
   }
 
-  @Test fun errorInEmitterImmediately() {
+  @Test fun errorInEmitterImmediately() = runTest {
+    val job = Job()
     val clock = BroadcastFrameClock()
-    val scope = CoroutineScope(UnconfinedTestDispatcher() + clock)
+    val scope = CoroutineScope(coroutineContext + job + clock)
 
     // Use a custom subtype to prevent coroutines from breaking referential equality.
     val runtimeException = object : RuntimeException() {}
@@ -179,7 +179,7 @@ class MoleculeTest {
       }
     }.isSameInstanceAs(runtimeException)
 
-    scope.cancel()
+    job.cancelAndJoin()
   }
 
   @Test fun errorInEmitterDelayed() = runTest {

--- a/molecule-runtime/src/commonTest/kotlin/app/cash/molecule/MoleculeTest.kt
+++ b/molecule-runtime/src/commonTest/kotlin/app/cash/molecule/MoleculeTest.kt
@@ -47,6 +47,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
@@ -97,7 +98,7 @@ class MoleculeTest {
 
   @Test fun errorImmediately() {
     val clock = BroadcastFrameClock()
-    val scope = CoroutineScope(clock)
+    val scope = CoroutineScope(UnconfinedTestDispatcher() + clock)
 
     // Use a custom subtype to prevent coroutines from breaking referential equality.
     val runtimeException = object : RuntimeException() {}
@@ -168,7 +169,7 @@ class MoleculeTest {
 
   @Test fun errorInEmitterImmediately() {
     val clock = BroadcastFrameClock()
-    val scope = CoroutineScope(clock)
+    val scope = CoroutineScope(UnconfinedTestDispatcher() + clock)
 
     // Use a custom subtype to prevent coroutines from breaking referential equality.
     val runtimeException = object : RuntimeException() {}


### PR DESCRIPTION
This PR is an effort to address the issue in [#544](https://github.com/cashapp/molecule/issues/544)

### Cause
After adding some extensive logging, I discovered that the error is not with `errorInEmitterDelayed` but instead the `errorImmediately` and `errorInEmitterImmediately` tests. The flakiness in these tests appears to be caused by cancellation leaking between tests. 

I noticed that when I added a log inside the catch block of `recomposer.runRecomposeAndApplyChanges()` inside `launchMolecule()` the cancellation log from the immediately tests would leak into the delayed tests:
```kotlin
public fun <T> CoroutineScope.launchMolecule(
  mode: RecompositionMode,
  emitter: (value: T) -> Unit,
  context: CoroutineContext = EmptyCoroutineContext,
  body: @Composable () -> T,
) {
  ..
  launch(finalContext, start = UNDISPATCHED) {
    try {
      recomposer.runRecomposeAndApplyChanges()
    } catch (e: CancellationException) {
      println("runRecomposeAndApplyChanges() cause: ${e.cause}")
      composition.dispose()
      snapshotHandle?.dispose()
    }
  }
  ..
}

// MoleculeTest.kt
@Test fun errorImmediately() {
   ..
  scope.cancel("errorImmediately")
}
```

<img width="850" src="https://github.com/user-attachments/assets/818712be-9153-4902-96af-d54206f73aae" />
<p/>

The flakiness came down to a timing issue:
- If the leaked cancellationException occurred before the first `registerGlobalWriteObserver` it went unnoticed. From what I saw, this appeared to always be the case with the android tests. 
- However with the macosArm64 and iosSimulatorArm64 platforms, what I would see is it would occur after `registerGlobalWriteObserver` and the cancellation would swallow the pending recomposition inside `runRecomposeAndApplyChanges()`, preventing the simulated runtimeException from being thown.

### Solution
Updating the immediately tests calling `scope.cancel()` with using UnconfinedTestDispatcher() appears to have solved the issue for me locally. Can't say with complete certainty this solves the issue as it was difficult reproducing the error without any changes, but it does consistently contain the scope cancellation within those tests. Alternatively you could add `runTest` to these and use its coroutineContext + job + clock for the CoroutineScope, but that maybe defeats the purpose of the immediately context of these tests.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
