### PR TITLE
Fix errorDelayed flaky tests

### DIFF
--- a/molecule-runtime/src/commonMain/kotlin/app/cash/molecule/molecule.kt
+++ b/molecule-runtime/src/commonMain/kotlin/app/cash/molecule/molecule.kt
@@ -24,7 +24,6 @@ import androidx.compose.runtime.snapshots.Snapshot
 import kotlin.DeprecationLevel.HIDDEN
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
-import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart.UNDISPATCHED
 import kotlinx.coroutines.channels.Channel
@@ -180,7 +179,7 @@ public fun <T> CoroutineScope.launchMolecule(
   launch(finalContext, start = UNDISPATCHED) {
     try {
       recomposer.runRecomposeAndApplyChanges()
-    } catch (e: CancellationException) {
+    } finally {
       composition.dispose()
       snapshotHandle?.dispose()
     }

--- a/molecule-runtime/src/commonTest/kotlin/app/cash/molecule/MoleculeStateFlowTest.kt
+++ b/molecule-runtime/src/commonTest/kotlin/app/cash/molecule/MoleculeStateFlowTest.kt
@@ -21,19 +21,19 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshots.Snapshot
 import app.cash.molecule.RecompositionMode.ContextClock
 import app.cash.molecule.RecompositionMode.Immediate
 import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isSameInstanceAs
+import assertk.assertions.isTrue
 import kotlin.test.Test
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.job
@@ -83,12 +83,13 @@ class MoleculeStateFlowTest {
     clock.sendFrame(0)
     assertThat(flow.value).isEqualTo(2)
 
-    job.cancel()
+    job.cancelAndJoin()
   }
 
-  @Test fun errorImmediately() {
+  @Test fun errorImmediately() = runTest {
+    val job = Job()
     val clock = BroadcastFrameClock()
-    val scope = CoroutineScope(clock)
+    val scope = CoroutineScope(coroutineContext + job + clock)
 
     // Use a custom subtype to prevent coroutines from breaking referential equality.
     val runtimeException = object : RuntimeException() {}
@@ -98,7 +99,8 @@ class MoleculeStateFlowTest {
       }
     }.isSameInstanceAs(runtimeException)
 
-    scope.cancel()
+    // This exception is processed in `composeInitial` and not `runRecomposeAndApplyChanges`, so the job is still active.
+    job.cancelAndJoin()
   }
 
   @Test fun errorDelayed() = runTest {
@@ -121,13 +123,13 @@ class MoleculeStateFlowTest {
     assertThat(flow.value).isEqualTo(0)
 
     count++
-    Snapshot.sendApplyNotifications() // Ensure external state mutation is observed.
     runCurrent()
     clock.sendFrame(0)
     runCurrent()
     assertThat(exceptionHandler.exceptions.single()).isSameInstanceAs(runtimeException)
 
-    job.cancel()
+    // Verify `runRecomposeAndApplyChanges` is no longer active.
+    assertThat(job.isCompleted).isTrue()
   }
 
   @Test fun errorInEffect() = runTest {
@@ -153,7 +155,8 @@ class MoleculeStateFlowTest {
     clock.sendFrame(0)
     assertThat(exceptionHandler.exceptions.single()).isSameInstanceAs(runtimeException)
 
-    job.cancel()
+    // Verify `runRecomposeAndApplyChanges` is no longer active.
+    assertThat(job.isCompleted).isTrue()
   }
 
   @Test
@@ -187,7 +190,7 @@ class MoleculeStateFlowTest {
     runCurrent()
     assertThat(flow.value).isEqualTo(2)
 
-    job.cancel()
+    job.cancelAndJoin()
   }
 
   @Test fun errorDelayedImmediate() = runTest {
@@ -215,6 +218,8 @@ class MoleculeStateFlowTest {
       job.join()
 
       assertThat(exceptionHandler.exceptions.single()).isSameInstanceAs(runtimeException)
+      // Verify `runRecomposeAndApplyChanges` is no longer active.
+      assertThat(job.isCompleted).isTrue()
     }
   }
 }

--- a/molecule-runtime/src/commonTest/kotlin/app/cash/molecule/MoleculeTest.kt
+++ b/molecule-runtime/src/commonTest/kotlin/app/cash/molecule/MoleculeTest.kt
@@ -24,7 +24,6 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshots.Snapshot
 import app.cash.molecule.MoleculeTest.DisposableEffectState.DISPOSED
 import app.cash.molecule.MoleculeTest.DisposableEffectState.LAUNCHED
 import app.cash.molecule.MoleculeTest.DisposableEffectState.NOT_LAUNCHED
@@ -35,13 +34,13 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotSameInstanceAs
 import assertk.assertions.isSameInstanceAs
+import assertk.assertions.isTrue
 import kotlin.test.Test
 import kotlin.test.fail
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
@@ -92,12 +91,13 @@ class MoleculeTest {
     clock.sendFrame(0)
     assertThat(value).isEqualTo(2)
 
-    job.cancel()
+    job.cancelAndJoin()
   }
 
-  @Test fun errorImmediately() {
+  @Test fun errorImmediately() = runTest {
+    val job = Job()
     val clock = BroadcastFrameClock()
-    val scope = CoroutineScope(clock)
+    val scope = CoroutineScope(coroutineContext + job + clock)
 
     // Use a custom subtype to prevent coroutines from breaking referential equality.
     val runtimeException = object : RuntimeException() {}
@@ -107,7 +107,10 @@ class MoleculeTest {
       }
     }.isSameInstanceAs(runtimeException)
 
-    scope.cancel()
+    // This exception is processed in `composeInitial` and not `runRecomposeAndApplyChanges`, so the job is still active.
+    runCurrent()
+    assertThat(job.isActive).isTrue()
+    job.cancelAndJoin()
   }
 
   @Test fun errorDelayed() = runTest {
@@ -130,13 +133,13 @@ class MoleculeTest {
     assertThat(value).isEqualTo(0)
 
     count++
-    Snapshot.sendApplyNotifications() // Ensure external state mutation is observed.
     runCurrent()
     clock.sendFrame(0)
     runCurrent()
     assertThat(exceptionHandler.exceptions.single()).isSameInstanceAs(runtimeException)
 
-    job.cancel()
+    // Verify `runRecomposeAndApplyChanges` is no longer active.
+    assertThat(job.isCompleted).isTrue()
   }
 
   @Test fun errorInEffect() = runTest {
@@ -163,12 +166,14 @@ class MoleculeTest {
     clock.sendFrame(0)
     assertThat(exceptionHandler.exceptions.single()).isSameInstanceAs(runtimeException)
 
-    job.cancel()
+    // Verify `runRecomposeAndApplyChanges` is no longer active.
+    assertThat(job.isCompleted).isTrue()
   }
 
-  @Test fun errorInEmitterImmediately() {
+  @Test fun errorInEmitterImmediately() = runTest {
+    val job = Job()
     val clock = BroadcastFrameClock()
-    val scope = CoroutineScope(clock)
+    val scope = CoroutineScope(coroutineContext + job + clock)
 
     // Use a custom subtype to prevent coroutines from breaking referential equality.
     val runtimeException = object : RuntimeException() {}
@@ -178,7 +183,8 @@ class MoleculeTest {
       }
     }.isSameInstanceAs(runtimeException)
 
-    scope.cancel()
+    // This exception is processed in `composeInitial` and not `runRecomposeAndApplyChanges`, so the job is still active.
+    job.cancelAndJoin()
   }
 
   @Test fun errorInEmitterDelayed() = runTest {
@@ -206,13 +212,13 @@ class MoleculeTest {
     assertThat(value).isEqualTo(0)
 
     count++
-    Snapshot.sendApplyNotifications() // Ensure external state mutation is observed.
     runCurrent()
     clock.sendFrame(0)
     runCurrent()
     assertThat(exceptionHandler.exceptions.single()).isSameInstanceAs(runtimeException)
 
-    job.cancel()
+    // Verify `runRecomposeAndApplyChanges` is no longer active.
+    assertThat(job.isCompleted).isTrue()
   }
 
   enum class DisposableEffectState { NOT_LAUNCHED, LAUNCHED, DISPOSED }
@@ -236,8 +242,7 @@ class MoleculeTest {
 
     assertThat(state).isEqualTo(LAUNCHED)
 
-    job.cancel()
-    runCurrent()
+    job.cancelAndJoin()
     assertThat(state).isEqualTo(DISPOSED)
   }
 
@@ -277,7 +282,7 @@ class MoleculeTest {
     value = values.awaitValue()
     assertThat(value).isEqualTo(5)
 
-    job.cancel()
+    job.cancelAndJoin()
   }
 
   @Test
@@ -298,7 +303,7 @@ class MoleculeTest {
     // Use a custom subtype to prevent coroutines from breaking referential equality.
     val runtimeException = object : RuntimeException() {}
     var count by mutableIntStateOf(0)
-    launch {
+    val job = launch {
       val exception = runCatching {
         moleculeFlow(mode = Immediate) {
           if (count == 1) {
@@ -315,7 +320,9 @@ class MoleculeTest {
     assertThat(values.awaitValue()).isEqualTo(0)
 
     count++
-    Snapshot.sendApplyNotifications() // Ensure external state mutation is observed.
+    runCurrent()
+    // Verify `runRecomposeAndApplyChanges` is no longer active.
+    assertThat(job.isCompleted).isTrue()
   }
 
   @Test
@@ -324,7 +331,7 @@ class MoleculeTest {
 
     // Use a custom subtype to prevent coroutines from breaking referential equality.
     val runtimeException = object : RuntimeException() {}
-    launch {
+    val job = launch {
       val exception = runCatching {
         moleculeFlow(mode = Immediate) {
           LaunchedEffect(Unit) {
@@ -341,7 +348,10 @@ class MoleculeTest {
 
     assertThat(values.awaitValue()).isEqualTo(0)
 
-    Snapshot.sendApplyNotifications() // Ensure external state mutation is observed.
+    advanceTimeBy(50)
+    runCurrent()
+    // Verify `runRecomposeAndApplyChanges` is no longer active.
+    assertThat(job.isCompleted).isTrue()
   }
 
   @Test
@@ -373,23 +383,27 @@ class MoleculeTest {
   }
 
   @Test fun coroutineContextUsed() = runTest {
+    val job = Job()
     val expectedName = CoroutineName("test_key")
 
     var actualName: CoroutineName? = null
-    backgroundScope.launchMolecule(Immediate, expectedName) {
+    backgroundScope.launchMolecule(Immediate, job + expectedName) {
       actualName = rememberCoroutineScope().coroutineContext[CoroutineName]
     }
     assertThat(actualName).isEqualTo(expectedName)
+    job.cancelAndJoin()
   }
 
   @Test fun coroutineContextClockDoesNotOverrideImmediate() = runTest {
+    val job = Job()
     val myClock = BroadcastFrameClock()
 
     var actualClock: MonotonicFrameClock? = null
-    backgroundScope.launchMolecule(Immediate, myClock) {
+    backgroundScope.launchMolecule(Immediate, job + myClock) {
       actualClock = rememberCoroutineScope().coroutineContext[MonotonicFrameClock]
     }
     assertThat(actualClock).isNotSameInstanceAs(myClock)
+    job.cancelAndJoin()
   }
 
   private suspend fun <T> Channel<T>.awaitValue(): T = withTimeout(1000) { receive() }

--- a/molecule-runtime/src/commonTest/kotlin/app/cash/molecule/MoleculeTest.kt
+++ b/molecule-runtime/src/commonTest/kotlin/app/cash/molecule/MoleculeTest.kt
@@ -108,8 +108,6 @@ class MoleculeTest {
     }.isSameInstanceAs(runtimeException)
 
     // This exception is processed in `composeInitial` and not `runRecomposeAndApplyChanges`, so the job is still active.
-    runCurrent()
-    assertThat(job.isActive).isTrue()
     job.cancelAndJoin()
   }
 


### PR DESCRIPTION
This should be a more robust solution for the [flaky test issues](https://github.com/cashapp/molecule/issues/544) that have occurred from these `errorDelayed` and `errorInEmitterDelayed` tests. 

I understand if changes to the molecule.kt class are beyond the scope of this issue, but I did observe scenarios where the coroutine launching `recomposer.runRecomposeAndApplyChanges()` would complete without throwing a CancellationException, and this would result in leaking the `snapshotHandle`. However the changes in the test class should remain flaky-free whether this change is accepted or not.

Early on I was fairly confident as to _what_ was causing this issue, which was coroutine/snapshotHandle leaking between tests. Whenever there's a flaky test situation where the success rate is this high, it's a fair assumption. But I wasn't able to figure _why_ and _how_ this was causing this issue until recently after combing through the Snapshot and Recomposer classes.

There were two things that would always occur in a failure result that would never occur in a successful result, and that was `clock.hasAwaiters` would be false and `Snapshot.isApplyObserverNotificationPending` would be true at this moment before attempting to call `clock.sendFrame(0)`
```kotlin
@Test fun errorDelayed() = runTest {
 ..
  count++
  runCurrent()
  if (!clock.hasAwaiters) {
    // Test is guaranteed to fail and `Snapshot.isApplyObserverNotificationPending` is always true
  }
  clock.sendFrame(0)
  runCurrent()
  ..
}
```

When I updated the `errorImmediately` and `errorInEmitterImmediately` tests to using `runTest` and added `job.cancelAndJoin()` at the end, I was unable to reproduce the test failures, but it wasn't adding up as to why `errorImmediately` would affect the result in `errorDelayed` when the tests don't share a coroutineScope or recomposer. The only thing they could share is a Snapshot. After going through the Snapshot and Recomposer classes, I think I might finally know why this was happening, and although the window is small, it isn't improbable. Here is the sequence of events that cause the error:

1. The `error_Immediately` snapshotHandle is still undisposed when the `error_Delayed` test begins.
    
    -  This was almost always the case even in successful tests, however the test ordering may vary by platform, and the issue is more likely to occur if a delayed test directly follows an immediate test.
2. The `error_Immediately` is cancelled and its snapshotHandle disposal begins after `count++`, intercepting the `advanceGlobalSnapshot` with modified changes.
    
    - This is another thing that can occur in successful test cases, but is always part of the failure process. 
    - When the disposal begins, it removes the global write observer and calls `advanceGlobalSnapshot`. Without `error_Delayed` updating the count, no modified changes would occur. However in this scenario, the `error_Delayed` creates the change (count++), but `error_Immediately` wins the race when it comes to who advances the snapshot with modified changes. I knew these methods were potentially significant as it's the only place where `pendingApplyObserverCount.add` occurs and this is what causes `Snapshot.isApplyObserverNotificationPending` to be true:
```kotlin
fun registerGlobalWriteObserver(observer: ((Any) -> Unit)): ObserverHandle {
  ..
  return ObserverHandle {
    sync {
      globalWriteObservers -= observer
    }
    advanceGlobalSnapshot()
  }
}

private fun <T> advanceGlobalSnapshot(block: (invalid: SnapshotIdSet) -> T): T {
  ..
  // Critical point
  modified?.let {
    try {
      val observers = applyObservers
      observers.fastForEach { observer ->
        observer(it.wrapIntoSet(), previousGlobalSnapshot)
      }
    } finally {
      pendingApplyObserverCount.add(-1)
    }
  }
  ..
}
```
    
3. The `error_Delayed`'s `clock.sendFrame(0)` occurs _before_ these changes are applied to the observers.
   
     - It took me a while to figure out why, but then I realized all of the `runCurrent()` calls in these tests have no effect since the Snapshot is being advanced from `error_Immediately`'s disposal. The `Snapshot.sendApplyNotifications()` calls are occurring, whether through the external call in the test or through the internal call inside `launchMolecule`, but they have no effect because this `changes` boolean is false at this point since the immediately test has taken a new snapshot (but not updated the observers yet)
```kotlin
fun sendApplyNotifications() {
  val changes = sync {
    currentGlobalSnapshot.get().modified?.isNotEmpty() == true
  }
  if (changes)
    advanceGlobalSnapshot()
}
```

I probably went way too in-depth there, but I'm fairly confident this is what is happening. If the immediately tests were using the same scheduler, the `runCurrent()` calls would complete this process and allow the recomposer to record the modification and tick the `withFrameNanos`, but because it isn't using a scheduler, the timing will be fairly random. I've observed scenarios where the immediately tests advance the global snapshot and succeed, but it's because it completes before that critical `sendFrame(0)` part.

I'm still skeptical about changing the try/catch to try/finally in your `launchMolecule` method as your team will be far more knowledgeable on how this should run, but through my testing I would see the `error_Delayed` tests' snapshotHandles still being notified of updates. This may not be something observed in production and more related to how `runTest` can hang when you have uncompleted coroutines. I can't think of a scenario where `runRecomposeAndApplyChanges()` would complete without a CancellationException and you would want to keep the composition and snapshotHandle around, but that scenario may certainly exist.

Closes #544

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
