### PR TITLE
Correctly propagate extra context to internal clock ticks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ New:
 - Nothing yet!
 
 Changed:
-- Nothing yet!
+- Any specified additional coroutine context elements will now be honored in the coroutine used internally with `RecompositionMode.Immediate` to send frames and cause recomposition to occur. This is observable, most notably, when a `CoroutineDispatcher` is included, as now recompositions which occur after the first, synchronous one will occur on that dispatcher.
 
 Fixed:
 - Correct calculation of frame nano time for native Windows and native Linux targets.

--- a/molecule-runtime/src/commonMain/kotlin/app/cash/molecule/GatedFrameClock.kt
+++ b/molecule-runtime/src/commonMain/kotlin/app/cash/molecule/GatedFrameClock.kt
@@ -17,6 +17,7 @@ package app.cash.molecule
 
 import androidx.compose.runtime.BroadcastFrameClock
 import androidx.compose.runtime.MonotonicFrameClock
+import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.CONFLATED
@@ -28,11 +29,14 @@ import kotlinx.coroutines.launch
  * While running, any request for a frame immediately succeeds. If stopped, requests for a frame wait until
  * the clock is set to run again.
  */
-internal class GatedFrameClock(scope: CoroutineScope) : MonotonicFrameClock {
+internal class GatedFrameClock(
+  scope: CoroutineScope,
+  context: CoroutineContext,
+) : MonotonicFrameClock {
   private val frameSends = Channel<Unit>(CONFLATED)
 
   init {
-    scope.launch {
+    scope.launch(context) {
       for (send in frameSends) sendFrame()
     }
   }

--- a/molecule-runtime/src/commonMain/kotlin/app/cash/molecule/RecompositionMode.kt
+++ b/molecule-runtime/src/commonMain/kotlin/app/cash/molecule/RecompositionMode.kt
@@ -25,12 +25,18 @@ public enum class RecompositionMode {
    * to determine when to run. If no clock is found in the context, an exception is thrown.
    *
    * Use this option to drive Molecule with a built-in frame clock or a custom one.
+   *
+   * After the initial, synchronous recomposition, future recompositions will run on a thread
+   * managed by the external clock.
    */
   ContextClock,
 
   /**
    * Run recomposition eagerly whenever one is needed.
    * Molecule will emit a new item every time the snapshot state is invalidated.
+   *
+   * After the initial, synchronous recomposition, future recompositions will run on a thread
+   * managed by the dispatcher from the coroutine context.
    */
   Immediate,
 }

--- a/molecule-runtime/src/commonMain/kotlin/app/cash/molecule/molecule.kt
+++ b/molecule-runtime/src/commonMain/kotlin/app/cash/molecule/molecule.kt
@@ -58,7 +58,7 @@ private fun <T> contextClockFlow(body: @Composable () -> T) = channelFlow {
 
 private fun <T> immediateClockFlow(body: @Composable () -> T): Flow<T> = flow {
   coroutineScope {
-    val clock = GatedFrameClock(this)
+    val clock = GatedFrameClock(this, EmptyCoroutineContext)
     val outputBuffer = Channel<T>(1)
 
     launch(clock, start = UNDISPATCHED) {
@@ -169,7 +169,7 @@ public fun <T> CoroutineScope.launchMolecule(
 ) {
   val clockContext = when (mode) {
     RecompositionMode.ContextClock -> EmptyCoroutineContext
-    RecompositionMode.Immediate -> GatedFrameClock(this)
+    RecompositionMode.Immediate -> GatedFrameClock(this, context)
   }
   val finalContext = coroutineContext + context + clockContext
 

--- a/molecule-runtime/src/commonTest/kotlin/app/cash/molecule/GatedFrameClockTest.kt
+++ b/molecule-runtime/src/commonTest/kotlin/app/cash/molecule/GatedFrameClockTest.kt
@@ -19,13 +19,14 @@ import assertk.all
 import assertk.assertThat
 import assertk.assertions.isLessThan
 import assertk.assertions.isPositive
+import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
 
 class GatedFrameClockTest {
   @Test
   fun ticksWithTime() = runTest {
-    val frameClock = GatedFrameClock(backgroundScope)
+    val frameClock = GatedFrameClock(backgroundScope, EmptyCoroutineContext)
     val frameTimeA = frameClock.withFrameNanos { it }
     val frameTimeB = frameClock.withFrameNanos { it }
     assertThat(frameTimeA).all {

--- a/molecule-runtime/src/jvmTest/kotlin/app/cash/molecule/MoleculeConcurrentTest.kt
+++ b/molecule-runtime/src/jvmTest/kotlin/app/cash/molecule/MoleculeConcurrentTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2025 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.molecule
+
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import app.cash.molecule.RecompositionMode.Immediate
+import assertk.assertThat
+import assertk.assertions.isNotSameInstanceAs
+import assertk.assertions.isSameInstanceAs
+import kotlin.test.Test
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.test.runTest
+
+// These tests are JVM only because they look at the current thread ID. It could be supported on
+// all platforms with threads, but all the code is common, so this just gets us coverage quickly.
+class MoleculeConcurrentTest {
+  @Test fun coroutineContextHonoredByImmediateClock() = runTest {
+    val testThread = Thread.currentThread()
+    var firstThread: Thread? = null
+    var secondThread: Thread? = null
+
+    val job = Job()
+    val cancelLatch = CompletableDeferred<Unit>()
+    backgroundScope.launchMolecule(Immediate, job + Dispatchers.Default) {
+      var count by remember { mutableIntStateOf(0) }
+      when (count) {
+        0 -> firstThread = Thread.currentThread()
+        1 -> secondThread = Thread.currentThread()
+      }
+      if (count == 1) {
+        cancelLatch.complete(Unit)
+      }
+      SideEffect {
+        count++
+      }
+    }
+    cancelLatch.await()
+
+    assertThat(firstThread).isSameInstanceAs(testThread)
+    assertThat(secondThread).isNotSameInstanceAs(testThread)
+
+    job.cancelAndJoin()
+  }
+}


### PR DESCRIPTION
Closes #591 

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
