### PR TITLE
Fix for hanging MoleculeConcurrentTest

### DIFF
--- a/molecule-runtime/src/jvmTest/kotlin/app/cash/molecule/MoleculeConcurrentTest.kt
+++ b/molecule-runtime/src/jvmTest/kotlin/app/cash/molecule/MoleculeConcurrentTest.kt
@@ -15,49 +15,78 @@
  */
 package app.cash.molecule
 
+import androidx.compose.runtime.RecomposeScope
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.currentRecomposeScope
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.Snapshot
 import app.cash.molecule.RecompositionMode.Immediate
 import assertk.assertThat
+import assertk.assertions.contains
 import assertk.assertions.isNotSameInstanceAs
 import assertk.assertions.isSameInstanceAs
 import kotlin.test.Test
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 
 // These tests are JVM only because they look at the current thread ID. It could be supported on
 // all platforms with threads, but all the code is common, so this just gets us coverage quickly.
+@ExperimentalCoroutinesApi
 class MoleculeConcurrentTest {
-  @Test fun coroutineContextHonoredByImmediateClock() = runTest {
+  @Test fun coroutineContextHonoredByImmediateClock() = runTest(UnconfinedTestDispatcher()) {
     val testThread = Thread.currentThread()
-    var firstThread: Thread? = null
-    var secondThread: Thread? = null
 
     val job = Job()
-    val cancelLatch = CompletableDeferred<Unit>()
+    val threadChannel = Channel<Thread>(Channel.UNLIMITED)
+    lateinit var recomposeScope: RecomposeScope
     backgroundScope.launchMolecule(Immediate, job + Dispatchers.Default) {
-      var count by remember { mutableIntStateOf(0) }
-      when (count) {
-        0 -> firstThread = Thread.currentThread()
-        1 -> secondThread = Thread.currentThread()
-      }
-      if (count == 1) {
-        cancelLatch.complete(Unit)
-      }
-      SideEffect {
-        count++
-      }
+      threadChannel.trySend(Thread.currentThread())
+      // This can be used to manually trigger recompositions outside of the composable.
+      val scope = currentRecomposeScope
+      SideEffect { recomposeScope = scope }
     }
-    cancelLatch.await()
 
+    val firstThread = threadChannel.receive()
     assertThat(firstThread).isSameInstanceAs(testThread)
+
+    recomposeScope.invalidate()
+
+    val secondThread = threadChannel.receive()
     assertThat(secondThread).isNotSameInstanceAs(testThread)
+    assertThat(secondThread.name).contains("DefaultDispatcher")
+
+    job.cancelAndJoin()
+  }
+
+  @Test fun coroutineContextHonoredByImmediateClockInEmitter() = runTest(UnconfinedTestDispatcher()) {
+    val testThread = Thread.currentThread()
+
+    val job = Job()
+    val threadChannel = Channel<Thread>(Channel.UNLIMITED)
+    var count by mutableIntStateOf(0)
+    backgroundScope.launchMolecule(
+      mode = Immediate,
+      context = job + Dispatchers.Default,
+      emitter = { threadChannel.trySend(Thread.currentThread()) },
+    ) {
+      count
+    }
+
+    val firstThread = threadChannel.receive()
+    assertThat(firstThread).isSameInstanceAs(testThread)
+
+    Snapshot.withMutableSnapshot { count++ }
+
+    val secondThread = threadChannel.receive()
+    assertThat(secondThread).isNotSameInstanceAs(testThread)
+    assertThat(secondThread.name).contains("DefaultDispatcher")
 
     job.cancelAndJoin()
   }


### PR DESCRIPTION
This should hopefully resolve the issue #613 for the hanging test. I believe this should achieve the desired results of verifying the Immediate clock starts on the current thread without the use of backward writes.

The existing test case had the risk of recomposing on every frame as it was writing state that had already been read within the composable. If UnconfinedTestDispatcher is undesirable, I can look into alternatives for making sure the recompositon runs predictably.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
