### PR TITLE
Use AndroidX Compose runtime

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,4 +23,12 @@
       extractVersionTemplate: '^(?<version>\\d+)',
     },
   ],
+  packageRules: [
+    {
+      packagePatterns: [
+        '^org.jetbrains.compose.runtime:runtime:',
+      ],
+      enabled: false,
+    },
+  ],
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 [Unreleased]: https://github.com/cashapp/molecule/compare/2.0.0...HEAD
 
 Changed:
+- Use the AndroidX Compose runtime which is now fully multiplatform. A dependency constraint to the JetBrains Compose runtime version 1.9.0 has been added, which is the first version that is empty and itself now points to AndroidX.
 - Android variant now has a minimum SDK level of 23.
 - In-development snapshots are now published to the Central Portal Snapshots repository at https://central.sonatype.com/repository/maven-snapshots/.
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,13 +4,13 @@ minSdk = "23"
 
 coroutine = "1.10.2"
 kotlin = "2.2.20"
-jetbrains-compose = "1.9.0"
 serialization = "1.9.0"
 squareup-okhttp = "5.1.0"
 squareup-retrofit = "3.0.0"
 
 [libraries]
 android-plugin = { module = "com.android.tools.build:gradle", version = "8.13.0" }
+androidx-compose-runtime = "androidx.compose.runtime:runtime:1.9.1"
 androidx-core = { module = "androidx.core:core-ktx", version = "1.17.0" }
 androidx-test-runner = { module = "androidx.test:runner", version = "1.7.0" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version = "1.11.0" }
@@ -18,8 +18,6 @@ androidx-activity-compose = { module = "androidx.activity:activity-compose", ver
 androidx-compose-material3 = "androidx.compose.material3:material3:1.3.2"
 
 coil-compose = "io.coil-kt:coil-compose:2.7.0"
-
-jetbrains-compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "jetbrains-compose" }
 
 dokka-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "2.0.0" }
 

--- a/molecule-runtime/build.gradle
+++ b/molecule-runtime/build.gradle
@@ -71,7 +71,7 @@ kotlin {
 
     commonMain {
       dependencies {
-        api libs.jetbrains.compose.runtime
+        api libs.androidx.compose.runtime
         api libs.kotlinx.coroutines.core
       }
     }
@@ -116,6 +116,12 @@ dependencies {
     capabilities {
       requireCapability(
         "org.jetbrains.kotlin:kotlin-test-framework-junit:${libs.versions.kotlin.get()}")
+    }
+  }
+
+  constraints {
+    commonMainApi("org.jetbrains.compose.runtime:runtime:1.9.0") {
+      because('AndroidX publishes multiplatform runtime. The JetBrains artifact is now empty.')
     }
   }
 }


### PR DESCRIPTION
Closes #664 

Tested manually. Here's an example showing the constraint dependency and it being applied:
```
jvmCompileClasspath - Compile classpath for 'jvm/main'.
+--- project :molecule-runtime
|    +--- androidx.compose.runtime:runtime:1.9.1
|    |    \--- androidx.compose.runtime:runtime-desktop:1.9.1
|    |         +--- androidx.compose.runtime:runtime-annotation:1.9.1
|    |         |    \--- androidx.compose.runtime:runtime-annotation-jvm:1.9.1
|    |         |         +--- org.jetbrains.kotlin:kotlin-stdlib -> 2.2.20
|    |         |         |    \--- org.jetbrains:annotations:13.0 -> 23.0.0
|    |         |         +--- androidx.compose.runtime:runtime:1.9.1 (c)
|    |         |         \--- org.jetbrains.kotlin:kotlin-stdlib:2.0.21 -> 2.2.20 (c)
|    |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1 -> 1.10.2
|    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.10.2
|    |         |         +--- org.jetbrains:annotations:23.0.0
|    |         |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.10.2
|    |         |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.10.2 (c)
|    |         |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2 (c)
|    |         |         \--- org.jetbrains.kotlin:kotlin-stdlib:2.1.0 -> 2.2.20 (*)
|    |         \--- androidx.compose.runtime:runtime-annotation:1.9.1 (c)
|    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2 (*)
|    +--- org.jetbrains.kotlin:kotlin-stdlib:2.2.20 (*)
|    \--- org.jetbrains.compose.runtime:runtime:1.9.0 (c)
+--- org.jetbrains.compose.runtime:runtime:1.8.2 -> 1.9.0
|    \--- org.jetbrains.compose.runtime:runtime-desktop:1.9.0
|         \--- androidx.compose.runtime:runtime:1.9.0 -> 1.9.1 (*)
\--- org.jetbrains.kotlin:kotlin-stdlib:2.2.20 (*)
```

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
