### PR TITLE
Replaced material icons with ImageVector

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ androidx-core = { module = "androidx.core:core-ktx", version = "1.17.0" }
 androidx-test-runner = { module = "androidx.test:runner", version = "1.7.0" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version = "1.11.0" }
 
-androidx-compose-material3 = "androidx.compose.material3:material3:1.3.2"
+androidx-compose-material3 = "androidx.compose.material3:material3:1.4.0"
 
 coil-compose = "io.coil-kt:coil-compose:2.7.0"
 

--- a/sample-viewmodel/src/main/java/com/example/molecule/viewmodel/ui.kt
+++ b/sample-viewmodel/src/main/java/com/example/molecule/viewmodel/ui.kt
@@ -43,8 +43,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.ArrowDropDown
 import androidx.compose.material3.Button
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
@@ -60,6 +58,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.compose.AsyncImagePainter
@@ -153,7 +153,7 @@ private fun CurrentBreedSelection(
         style = MaterialTheme.typography.titleMedium,
       )
       Icon(
-        imageVector = Icons.Rounded.ArrowDropDown,
+        imageVector = ImageVector.vectorResource(R.drawable.rounded_arrow_drop_down_24),
         contentDescription = null,
         modifier = Modifier.rotate(arrowRotation),
       )

--- a/sample-viewmodel/src/main/res/drawable/rounded_arrow_drop_down_24.xml
+++ b/sample-viewmodel/src/main/res/drawable/rounded_arrow_drop_down_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="24dp"
+  android:height="24dp"
+  android:viewportWidth="960"
+  android:viewportHeight="960">
+  <path
+    android:fillColor="#FF000000"
+    android:pathData="M459,579L314,434Q311,431 309.5,427.5Q308,424 308,420Q308,412 313.5,406Q319,400 328,400L632,400Q641,400 646.5,406Q652,412 652,420Q652,422 646,434L501,579Q496,584 491,586Q486,588 480,588Q474,588 469,586Q464,584 459,579Z" />
+</vector>


### PR DESCRIPTION
- Added the rounded_arrow_drop_down_24.xml directly from the Resource Manager now that material icons is no longer bundled with the material3 library.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
