### PR TITLE
  Fix flaky MoleculeConcurrentTest by replacing runTest with runBlocking

### DIFF
--- a/molecule-runtime/src/jvmTest/kotlin/app/cash/molecule/MoleculeConcurrentTest.kt
+++ b/molecule-runtime/src/jvmTest/kotlin/app/cash/molecule/MoleculeConcurrentTest.kt
@@ -41,25 +41,27 @@ class MoleculeConcurrentTest {
     var secondThread: Thread? = null
 
     val job = Job()
-    val cancelLatch = CompletableDeferred<Unit>()
-    launchMolecule(Immediate, job + Dispatchers.Default) {
-      var count by remember { mutableIntStateOf(0) }
-      when (count) {
-        0 -> firstThread = Thread.currentThread()
-        1 -> secondThread = Thread.currentThread()
+    try {
+      val cancelLatch = CompletableDeferred<Unit>()
+      launchMolecule(Immediate, job + Dispatchers.Default) {
+        var count by remember { mutableIntStateOf(0) }
+        when (count) {
+          0 -> firstThread = Thread.currentThread()
+          1 -> secondThread = Thread.currentThread()
+        }
+        if (count == 1) {
+          cancelLatch.complete(Unit)
+        }
+        SideEffect {
+          count++
+        }
       }
-      if (count == 1) {
-        cancelLatch.complete(Unit)
-      }
-      SideEffect {
-        count++
-      }
+      cancelLatch.await()
+
+      assertThat(firstThread).isSameInstanceAs(testThread)
+      assertThat(secondThread).isNotSameInstanceAs(testThread)
+    } finally {
+      job.cancelAndJoin()
     }
-    cancelLatch.await()
-
-    assertThat(firstThread).isSameInstanceAs(testThread)
-    assertThat(secondThread).isNotSameInstanceAs(testThread)
-
-    job.cancelAndJoin()
   }
 }

--- a/molecule-runtime/src/jvmTest/kotlin/app/cash/molecule/MoleculeConcurrentTest.kt
+++ b/molecule-runtime/src/jvmTest/kotlin/app/cash/molecule/MoleculeConcurrentTest.kt
@@ -29,19 +29,20 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
-import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.runBlocking
 
 // These tests are JVM only because they look at the current thread ID. It could be supported on
 // all platforms with threads, but all the code is common, so this just gets us coverage quickly.
 class MoleculeConcurrentTest {
-  @Test fun coroutineContextHonoredByImmediateClock() = runTest {
+  @Test
+  fun coroutineContextHonoredByImmediateClock() = runBlocking {
     val testThread = Thread.currentThread()
     var firstThread: Thread? = null
     var secondThread: Thread? = null
 
     val job = Job()
     val cancelLatch = CompletableDeferred<Unit>()
-    backgroundScope.launchMolecule(Immediate, job + Dispatchers.Default) {
+    launchMolecule(Immediate, job + Dispatchers.Default) {
       var count by remember { mutableIntStateOf(0) }
       when (count) {
         0 -> firstThread = Thread.currentThread()


### PR DESCRIPTION

  The root cause is that `runTest` uses `StandardTestDispatcher` which has a dispatch timeout mechanism. The test's `cancelLatch.await()` suspends the test body waiting for a
   recomposition on real `Dispatchers.Default` threads. Since `StandardTestDispatcher` has no pending tasks (all work is on `Dispatchers.Default`), `runTest` may time out or
  hang.

  `runBlocking` is the correct choice because:
  - The test uses real `Dispatchers.Default` (not virtual time)
  - `runBlocking` naturally blocks until async work completes with no artificial dispatch timeout
  - The test's structure (blocking on a `CompletableDeferred`) maps directly to `runBlocking` semantics

  ## Test plan
  - [x] `./gradlew :molecule-runtime:jvmTest --tests "app.cash.molecule.MoleculeConcurrentTest" --rerun` passes consistently (verified 5 consecutive runs)

  Fixes #613