### PR TITLE
Drop `watchosX64` target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [Unreleased]
 [Unreleased]: https://github.com/cashapp/molecule/compare/2.2.0...HEAD
 
-Nothing yet!
+Changed:
+- The deprecated `watchosX64` target has been removed.
 
 
 ## [2.2.0] - 2025-09-24

--- a/molecule-runtime/api/molecule-runtime.klib.api
+++ b/molecule-runtime/api/molecule-runtime.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosSimulatorArm64, watchosX64]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosSimulatorArm64]
 // Alias: ios => [iosArm64, iosSimulatorArm64, iosX64]
 // Alias: macos => [macosArm64, macosX64]
 // Alias: tvos => [tvosArm64, tvosSimulatorArm64, tvosX64]

--- a/molecule-runtime/build.gradle
+++ b/molecule-runtime/build.gradle
@@ -41,7 +41,6 @@ kotlin {
   watchosArm32()
   watchosArm64()
   watchosSimulatorArm64()
-  watchosX64()
 
   applyDefaultHierarchyTemplate {
     it.group("common") {


### PR DESCRIPTION
It's completely gone in the next Compose runtime version.
