### PR TITLE
AGP 9 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,9 @@
+import com.android.build.api.dsl.ApplicationExtension
+import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
+
 buildscript {
   dependencies {
-    classpath libs.android.plugin
+    classpath libs.android.plugin.api
     classpath libs.kotlin.plugin.core
     classpath libs.kotlin.plugin.compose
     classpath libs.kotlin.plugin.serialization
@@ -47,20 +50,29 @@ subprojects {
     }
   }
 
-  plugins.withType(com.android.build.gradle.BasePlugin).configureEach {
-    def android = extensions.getByName("android") as com.android.build.gradle.BaseExtension
-    android.compileSdkVersion libs.versions.compileSdk.get().toInteger()
+  pluginManager.withPlugin('com.android.application') {
+    def android = extensions.getByName("android") as ApplicationExtension
+    android.compileSdk = libs.versions.compileSdk.get().toInteger()
     android.defaultConfig {
-      minSdkVersion libs.versions.minSdk.get().toInteger()
-      targetSdkVersion libs.versions.compileSdk.get().toInteger()
+      minSdk = libs.versions.minSdk.get().toInteger()
+      targetSdk = libs.versions.compileSdk.get().toInteger()
     }
-    android.compileOptions {
-      sourceCompatibility JavaVersion.VERSION_11
-      targetCompatibility JavaVersion.VERSION_11
-    }
-    android.lintOptions {
+
+    android.lint {
       checkDependencies true
       checkReleaseBuilds false // Full lint runs as part of 'build' task.
+    }
+  }
+
+  pluginManager.withPlugin('org.jetbrains.kotlin.multiplatform') {
+    kotlin.targets.withType(KotlinMultiplatformAndroidLibraryTarget).configureEach {
+      compileSdk = libs.versions.compileSdk.get().toInteger()
+      minSdk = libs.versions.minSdk.get().toInteger()
+
+      lint {
+        checkDependencies = true
+        checkReleaseBuilds = false // Full lint runs as part of 'build' task.
+      }
     }
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
 
 buildscript {
   dependencies {
-    classpath libs.android.plugin.api
+    classpath libs.android.plugin
     classpath libs.kotlin.plugin.core
     classpath libs.kotlin.plugin.compose
     classpath libs.kotlin.plugin.serialization

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 buildscript {
   dependencies {
@@ -57,7 +58,10 @@ subprojects {
       minSdk = libs.versions.minSdk.get().toInteger()
       targetSdk = libs.versions.compileSdk.get().toInteger()
     }
-
+    android.compileOptions {
+      sourceCompatibility JavaVersion.VERSION_11
+      targetCompatibility JavaVersion.VERSION_11
+    }
     android.lint {
       checkDependencies true
       checkReleaseBuilds false // Full lint runs as part of 'build' task.
@@ -68,7 +72,9 @@ subprojects {
     kotlin.targets.withType(KotlinMultiplatformAndroidLibraryTarget).configureEach {
       compileSdk = libs.versions.compileSdk.get().toInteger()
       minSdk = libs.versions.minSdk.get().toInteger()
-
+      compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_11)
+      }
       lint {
         checkDependencies = true
         checkReleaseBuilds = false // Full lint runs as part of 'build' task.

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,9 +26,6 @@ org.gradle.jvmargs=-Xmx4096m
 
 android.useAndroidX=true
 android.enableJetifier=false
-android.defaults.buildfeatures.buildconfig=false
-android.defaults.buildfeatures.aidl=false
-android.defaults.buildfeatures.renderscript=false
 android.defaults.buildfeatures.resvalues=false
 android.defaults.buildfeatures.shaders=false
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ squareup-okhttp = "5.3.2"
 squareup-retrofit = "3.0.0"
 
 [libraries]
-android-plugin-api = { module = "com.android.tools.build:gradle-api", version = "9.1.0" }
+android-plugin = { module = "com.android.tools.build:gradle", version = "9.1.0" }
 androidx-compose-runtime = "androidx.compose.runtime:runtime:1.10.6"
 androidx-core = { module = "androidx.core:core-ktx", version = "1.18.0" }
 androidx-test-runner = { module = "androidx.test:runner", version = "1.7.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ squareup-okhttp = "5.3.2"
 squareup-retrofit = "3.0.0"
 
 [libraries]
-android-plugin = { module = "com.android.tools.build:gradle", version = "8.13.2" }
+android-plugin-api = { module = "com.android.tools.build:gradle-api", version = "9.1.0" }
 androidx-compose-runtime = "androidx.compose.runtime:runtime:1.10.6"
 androidx-core = { module = "androidx.core:core-ktx", version = "1.18.0" }
 androidx-test-runner = { module = "androidx.test:runner", version = "1.7.0" }

--- a/molecule-runtime/build.gradle
+++ b/molecule-runtime/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'com.android.library'
+apply plugin: 'com.android.kotlin.multiplatform.library'
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 apply plugin: 'org.jetbrains.kotlin.plugin.compose'
 apply plugin: 'com.vanniktech.maven.publish'
@@ -8,9 +8,25 @@ apply plugin: 'org.jetbrains.kotlinx.binary-compatibility-validator'
 kotlin {
   explicitApi()
 
-  androidTarget {
-    publishLibraryVariants('release')
+  android {
+    namespace 'app.cash.molecule'
+
+    withDeviceTestBuilder {
+      sourceSetTreeName = 'test'
+    }.configure {
+      instrumentationRunner = 'androidx.test.runner.AndroidJUnitRunner'
+    }
+
+    withHostTest {
+      returnDefaultValues = true
+    }
+
+    packaging.resources {
+      excludes += 'META-INF/AL2.0'
+      excludes += 'META-INF/LGPL2.1'
+    }
   }
+
 
   iosArm64()
   iosSimulatorArm64()
@@ -87,51 +103,34 @@ kotlin {
     }
 
     androidMain {
+      dependsOn(javaMain)
       dependencies {
         implementation libs.androidx.core
+      }
+    }
+
+    androidDeviceTest {
+      kotlin.srcDir('src/androidInstrumentedTest/kotlin')
+      dependencies {
+        implementation libs.androidx.test.runner
+        implementation libs.junit
+        implementation libs.assertk
+        implementation libs.kotlinx.coroutines.test
+        implementation libs.kotlin.test
       }
     }
   }
 }
 
 dependencies {
-  androidTestImplementation libs.androidx.test.runner
-  androidTestImplementation libs.junit
-  androidTestImplementation libs.assertk
-  androidTestImplementation libs.kotlinx.coroutines.test
-
   // The kotlin.test library provides JVM variants for multiple testing frameworks. When used
   // as a test dependency this selection is transparent. But since we are using from an Android
   // configuration we have to select the desired variant via an explicit capability.
-  add("androidTestImplementation", libs.kotlin.test) {
+  add("androidDeviceTestImplementation", libs.kotlin.test) {
     capabilities {
       requireCapability(
         "org.jetbrains.kotlin:kotlin-test-framework-junit:${libs.versions.kotlin.get()}")
     }
-  }
-}
-
-android {
-  namespace 'app.cash.molecule'
-
-  sourceSets {
-    androidTest {
-      java.srcDirs += 'src/commonTest/kotlin'
-      java.srcDirs += 'src/javaTest/kotlin'
-    }
-  }
-
-  defaultConfig {
-    testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
-  }
-
-  testOptions {
-    unitTests.returnDefaultValues = true
-  }
-
-  packagingOptions {
-    exclude 'META-INF/AL2.0'
-    exclude 'META-INF/LGPL2.1'
   }
 }
 

--- a/molecule-runtime/build.gradle
+++ b/molecule-runtime/build.gradle
@@ -27,7 +27,6 @@ kotlin {
     }
   }
 
-
   iosArm64()
   iosSimulatorArm64()
   iosX64()
@@ -116,7 +115,6 @@ kotlin {
         implementation libs.junit
         implementation libs.assertk
         implementation libs.kotlinx.coroutines.test
-        implementation libs.kotlin.test
       }
     }
   }

--- a/sample-viewmodel/build.gradle
+++ b/sample-viewmodel/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.application'
-apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: 'org.jetbrains.kotlin.plugin.compose'
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 
@@ -24,10 +23,10 @@ android {
   testOptions {
     unitTests.returnDefaultValues = true
   }
+}
 
-  variantFilter { variant ->
-    if (variant.buildType.name == 'release') {
-      setIgnore(true)
-    }
+androidComponents {
+  beforeVariants(selector().withBuildType('release')) { variant ->
+    variant.enable = false
   }
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.application'
-apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: 'org.jetbrains.kotlin.plugin.compose'
 
 dependencies {
@@ -25,10 +24,10 @@ android {
   testOptions {
     unitTests.returnDefaultValues = true
   }
+}
 
-  variantFilter { variant ->
-    if (variant.buildType.name == 'release') {
-      setIgnore(true)
-    }
+androidComponents {
+  beforeVariants(selector().withBuildType('release')) { variant ->
+    variant.enable = false
   }
 }


### PR DESCRIPTION
Main changes are in molecule-runtime's build.gradle and the root build.gradle. Most info about the changes can be found [here](https://developer.android.com/kotlin/multiplatform/plugin). Basically moving the android block into kotlin block and replacing `androidTarget`. Also replacing `com.android.library` with `com.android.kotlin.multiplatform.library`. You can declare direct dependencies on `androidDeviceTest` now, so most of that logic got moved there while keeping the `kotlin-test-framework-junit` logic in the separate dependencies block.

Had to remove the BaseExtension logic from the root build.gradle. I tried to see if I could get something with CommonExtension to work, but ran into issues with the new `com.android.kotlin.multiplatform.library` plugin. So instead I separated this into two listeners for that plugin and `com.android.application`. Let me know if there is a better alternative.

The rest of the changes were removing the `org.jetbrains.kotlin.android` plugin from the samples while replacing variantFilters with androidComponents beforeVariants.

My groovy knowledge isn't the best anymore, so let me know if I'm using any incorrect syntax.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
