### PR TITLE
Fix launchMolecule startup cancellation race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 Changed:
 - The deprecated `iosX64`, `macosX64`, `tvosX64`, and `watchosX64` targets have been removed.
 
+Fixed:
+- Cancelling a coroutine context during Molecule startup no longer causes `launchMolecule` to call `setContent` on a disposed composition.
+
 
 ## [2.2.0] - 2025-09-24
 [2.2.0]: https://github.com/cashapp/molecule/releases/tag/2.2.0

--- a/molecule-runtime/src/commonMain/kotlin/app/cash/molecule/molecule.kt
+++ b/molecule-runtime/src/commonMain/kotlin/app/cash/molecule/molecule.kt
@@ -26,8 +26,6 @@ import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart.UNDISPATCHED
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -36,7 +34,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 @Deprecated("", level = HIDDEN) // For binary compatibility.
 public fun <T> moleculeFlow(mode: RecompositionMode, body: @Composable () -> T): Flow<T> {
@@ -234,19 +231,8 @@ public fun <T> CoroutineScope.launchMolecule(
   val composition = Composition(UnitApplier, recomposer)
 
   var snapshotHandle: ObserverHandle? = null
-
-  val initialComposition = Job()
-  val runRecompose = launch(finalContext, start = UNDISPATCHED) {
-    try {
-      recomposer.runRecomposeAndApplyChanges()
-    } finally {
-      withContext(NonCancellable) {
-        initialComposition.join()
-        composition.dispose()
-        snapshotHandle?.dispose()
-        snapshotHandle = null
-      }
-    }
+  val recomposerJob = launch(finalContext, start = UNDISPATCHED) {
+    recomposer.runRecomposeAndApplyChanges()
   }
 
   try {
@@ -271,13 +257,13 @@ public fun <T> CoroutineScope.launchMolecule(
       emitter(body())
     }
   } catch (throwable: Throwable) {
-    snapshotHandle?.dispose()
-    snapshotHandle = null
     recomposer.cancel()
-    runRecompose.cancel()
     throw throwable
   } finally {
-    initialComposition.complete()
+    recomposerJob.invokeOnCompletion {
+      composition.dispose()
+      snapshotHandle?.dispose()
+    }
   }
 }
 

--- a/molecule-runtime/src/commonMain/kotlin/app/cash/molecule/molecule.kt
+++ b/molecule-runtime/src/commonMain/kotlin/app/cash/molecule/molecule.kt
@@ -223,11 +223,14 @@ public fun <T> CoroutineScope.launchMolecule(
   snapshotNotifier: SnapshotNotifier = defaultSnapshotNotifier(),
   body: @Composable () -> T,
 ) {
+  val baseContext = coroutineContext + context
+  if (!baseContext.isActive) return
+
   val clockContext = when (mode) {
     RecompositionMode.ContextClock -> EmptyCoroutineContext
     RecompositionMode.Immediate -> GatedFrameClock(this, context)
   }
-  val finalContext = coroutineContext + context + clockContext
+  val finalContext = baseContext + clockContext
 
   val recomposer = Recomposer(finalContext)
   val composition = Composition(UnitApplier, recomposer)

--- a/molecule-runtime/src/commonMain/kotlin/app/cash/molecule/molecule.kt
+++ b/molecule-runtime/src/commonMain/kotlin/app/cash/molecule/molecule.kt
@@ -24,16 +24,17 @@ import androidx.compose.runtime.snapshots.Snapshot
 import kotlin.DeprecationLevel.HIDDEN
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart.UNDISPATCHED
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
 @Deprecated("", level = HIDDEN) // For binary compatibility.
@@ -172,7 +173,7 @@ public fun <T> CoroutineScope.launchMolecule(
     body = body,
   )
 
-  return flow!!
+  return flow ?: throw CancellationException("launchMolecule was cancelled before producing an initial value")
 }
 
 @Deprecated("", level = HIDDEN) // For binary compatibility.
@@ -232,36 +233,50 @@ public fun <T> CoroutineScope.launchMolecule(
   val composition = Composition(UnitApplier, recomposer)
 
   var snapshotHandle: ObserverHandle? = null
+
   val recomposerJob = launch(finalContext, start = UNDISPATCHED) {
-    recomposer.runRecomposeAndApplyChanges()
+    try {
+      recomposer.runRecomposeAndApplyChanges()
+    } finally {
+      composition.dispose()
+      snapshotHandle?.dispose()
+      snapshotHandle = null
+    }
   }
 
-  when (snapshotNotifier) {
-    SnapshotNotifier.External -> {}
+  var startupCompleted = false
+  try {
+    if (!finalContext.isActive) return
 
-    SnapshotNotifier.WhileActive -> {
-      var applyScheduled = false
-      snapshotHandle = Snapshot.registerGlobalWriteObserver {
-        if (!applyScheduled) {
-          applyScheduled = true
-          launch(finalContext) {
-            applyScheduled = false
-            Snapshot.sendApplyNotifications()
+    when (snapshotNotifier) {
+      SnapshotNotifier.External -> {}
+
+      SnapshotNotifier.WhileActive -> {
+        var applyScheduled = false
+        snapshotHandle = Snapshot.registerGlobalWriteObserver {
+          if (!applyScheduled) {
+            applyScheduled = true
+            launch(finalContext) {
+              applyScheduled = false
+              Snapshot.sendApplyNotifications()
+            }
           }
         }
       }
     }
-  }
 
-  try {
-    finalContext.ensureActive()
+    if (!finalContext.isActive) return
+
     composition.setContent {
       emitter(body())
     }
+    startupCompleted = true
   } finally {
-    recomposerJob.invokeOnCompletion {
-      composition.dispose()
+    if (!startupCompleted) {
       snapshotHandle?.dispose()
+      snapshotHandle = null
+      recomposer.cancel()
+      recomposerJob.cancel()
     }
   }
 }

--- a/molecule-runtime/src/commonMain/kotlin/app/cash/molecule/molecule.kt
+++ b/molecule-runtime/src/commonMain/kotlin/app/cash/molecule/molecule.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart.UNDISPATCHED
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -231,13 +232,8 @@ public fun <T> CoroutineScope.launchMolecule(
   val composition = Composition(UnitApplier, recomposer)
 
   var snapshotHandle: ObserverHandle? = null
-  launch(finalContext, start = UNDISPATCHED) {
-    try {
-      recomposer.runRecomposeAndApplyChanges()
-    } finally {
-      composition.dispose()
-      snapshotHandle?.dispose()
-    }
+  val recomposerJob = launch(finalContext, start = UNDISPATCHED) {
+    recomposer.runRecomposeAndApplyChanges()
   }
 
   when (snapshotNotifier) {
@@ -257,8 +253,16 @@ public fun <T> CoroutineScope.launchMolecule(
     }
   }
 
-  composition.setContent {
-    emitter(body())
+  try {
+    finalContext.ensureActive()
+    composition.setContent {
+      emitter(body())
+    }
+  } finally {
+    recomposerJob.invokeOnCompletion {
+      composition.dispose()
+      snapshotHandle?.dispose()
+    }
   }
 }
 

--- a/molecule-runtime/src/commonMain/kotlin/app/cash/molecule/molecule.kt
+++ b/molecule-runtime/src/commonMain/kotlin/app/cash/molecule/molecule.kt
@@ -24,9 +24,10 @@ import androidx.compose.runtime.snapshots.Snapshot
 import kotlin.DeprecationLevel.HIDDEN
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart.UNDISPATCHED
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
@@ -34,8 +35,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @Deprecated("", level = HIDDEN) // For binary compatibility.
 public fun <T> moleculeFlow(mode: RecompositionMode, body: @Composable () -> T): Flow<T> {
@@ -173,7 +174,7 @@ public fun <T> CoroutineScope.launchMolecule(
     body = body,
   )
 
-  return flow ?: throw CancellationException("launchMolecule was cancelled before producing an initial value")
+  return flow!!
 }
 
 @Deprecated("", level = HIDDEN) // For binary compatibility.
@@ -223,34 +224,32 @@ public fun <T> CoroutineScope.launchMolecule(
   snapshotNotifier: SnapshotNotifier = defaultSnapshotNotifier(),
   body: @Composable () -> T,
 ) {
-  val baseContext = coroutineContext + context
-  if (!baseContext.isActive) return
-
   val clockContext = when (mode) {
     RecompositionMode.ContextClock -> EmptyCoroutineContext
     RecompositionMode.Immediate -> GatedFrameClock(this, context)
   }
-  val finalContext = baseContext + clockContext
+  val finalContext = coroutineContext + context + clockContext
 
   val recomposer = Recomposer(finalContext)
   val composition = Composition(UnitApplier, recomposer)
 
   var snapshotHandle: ObserverHandle? = null
 
-  val recomposerJob = launch(finalContext, start = UNDISPATCHED) {
+  val initialComposition = Job()
+  val runRecompose = launch(finalContext, start = UNDISPATCHED) {
     try {
       recomposer.runRecomposeAndApplyChanges()
     } finally {
-      composition.dispose()
-      snapshotHandle?.dispose()
-      snapshotHandle = null
+      withContext(NonCancellable) {
+        initialComposition.join()
+        composition.dispose()
+        snapshotHandle?.dispose()
+        snapshotHandle = null
+      }
     }
   }
 
-  var startupCompleted = false
   try {
-    if (!finalContext.isActive) return
-
     when (snapshotNotifier) {
       SnapshotNotifier.External -> {}
 
@@ -268,19 +267,17 @@ public fun <T> CoroutineScope.launchMolecule(
       }
     }
 
-    if (!finalContext.isActive) return
-
     composition.setContent {
       emitter(body())
     }
-    startupCompleted = true
+  } catch (throwable: Throwable) {
+    snapshotHandle?.dispose()
+    snapshotHandle = null
+    recomposer.cancel()
+    runRecompose.cancel()
+    throw throwable
   } finally {
-    if (!startupCompleted) {
-      snapshotHandle?.dispose()
-      snapshotHandle = null
-      recomposer.cancel()
-      recomposerJob.cancel()
-    }
+    initialComposition.complete()
   }
 }
 

--- a/molecule-runtime/src/commonTest/kotlin/app/cash/molecule/MoleculeStateFlowTest.kt
+++ b/molecule-runtime/src/commonTest/kotlin/app/cash/molecule/MoleculeStateFlowTest.kt
@@ -30,9 +30,6 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isSameInstanceAs
 import assertk.assertions.isTrue
 import kotlin.test.Test
-import kotlin.test.assertFailsWith
-import kotlin.test.fail
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -108,18 +105,25 @@ class MoleculeStateFlowTest {
     job.cancelAndJoin()
   }
 
-  @Test fun cancelledContextFailsBeforeComposing() = runTest {
+  @Test fun cancelledContextComposesInitialValueBeforeStopping() = runTest {
     for (mode in listOf(ContextClock, Immediate)) {
       val job = Job()
       val scope = CoroutineScope(coroutineContext + BroadcastFrameClock())
+      var effectRan = false
 
       job.cancel()
 
-      assertFailsWith<CancellationException> {
-        scope.launchMolecule<Int>(mode, context = job) {
-          fail()
+      val flow = scope.launchMolecule<Int>(mode, context = job) {
+        LaunchedEffect(Unit) {
+          effectRan = true
         }
+        1
       }
+      runCurrent()
+
+      assertThat(flow.value).isEqualTo(1)
+      assertThat(effectRan).isEqualTo(false)
+      assertThat(job.children.toList()).isEmpty()
     }
   }
 

--- a/molecule-runtime/src/commonTest/kotlin/app/cash/molecule/MoleculeStateFlowTest.kt
+++ b/molecule-runtime/src/commonTest/kotlin/app/cash/molecule/MoleculeStateFlowTest.kt
@@ -25,10 +25,14 @@ import app.cash.molecule.RecompositionMode.ContextClock
 import app.cash.molecule.RecompositionMode.Immediate
 import assertk.assertFailure
 import assertk.assertThat
+import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isSameInstanceAs
 import assertk.assertions.isTrue
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.fail
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -99,8 +103,24 @@ class MoleculeStateFlowTest {
       }
     }.isSameInstanceAs(runtimeException)
 
-    // This exception is processed in `composeInitial` and not `runRecomposeAndApplyChanges`, so the job is still active.
+    runCurrent()
+    assertThat(job.children.toList()).isEmpty()
     job.cancelAndJoin()
+  }
+
+  @Test fun cancelledContextFailsBeforeComposing() = runTest {
+    for (mode in listOf(ContextClock, Immediate)) {
+      val job = Job()
+      val scope = CoroutineScope(coroutineContext + BroadcastFrameClock())
+
+      job.cancel()
+
+      assertFailsWith<CancellationException> {
+        scope.launchMolecule<Int>(mode, context = job) {
+          fail()
+        }
+      }
+    }
   }
 
   @Test fun errorDelayed() = runTest {

--- a/molecule-runtime/src/commonTest/kotlin/app/cash/molecule/MoleculeStateFlowTest.kt
+++ b/molecule-runtime/src/commonTest/kotlin/app/cash/molecule/MoleculeStateFlowTest.kt
@@ -119,9 +119,9 @@ class MoleculeStateFlowTest {
         }
         1
       }
-      runCurrent()
-
       assertThat(flow.value).isEqualTo(1)
+
+      runCurrent()
       assertThat(effectRan).isEqualTo(false)
       assertThat(job.children.toList()).isEmpty()
     }

--- a/molecule-runtime/src/commonTest/kotlin/app/cash/molecule/MoleculeTest.kt
+++ b/molecule-runtime/src/commonTest/kotlin/app/cash/molecule/MoleculeTest.kt
@@ -39,7 +39,9 @@ import assertk.assertions.isNotSameInstanceAs
 import assertk.assertions.isSameInstanceAs
 import assertk.assertions.isTrue
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
 import kotlin.test.fail
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -112,6 +114,21 @@ class MoleculeTest {
 
     // This exception is processed in `composeInitial` and not `runRecomposeAndApplyChanges`, so the job is still active.
     job.cancelAndJoin()
+  }
+
+  @Test fun cancelledContextFailsBeforeComposing() = runTest {
+    for (mode in listOf(ContextClock, Immediate)) {
+      val job = Job()
+      val scope = CoroutineScope(coroutineContext + BroadcastFrameClock())
+
+      job.cancel()
+
+      assertFailsWith<CancellationException> {
+        scope.launchMolecule<Int>(mode, emitter = { fail() }, context = job) {
+          fail()
+        }
+      }
+    }
   }
 
   @Test fun errorDelayed() = runTest {

--- a/molecule-runtime/src/commonTest/kotlin/app/cash/molecule/MoleculeTest.kt
+++ b/molecule-runtime/src/commonTest/kotlin/app/cash/molecule/MoleculeTest.kt
@@ -116,16 +116,21 @@ class MoleculeTest {
     job.cancelAndJoin()
   }
 
-  @Test fun cancelledContextReturnsBeforeComposing() = runTest {
+  @Test fun cancelledContextComposesInitialValueBeforeStopping() = runTest {
     for (mode in listOf(ContextClock, Immediate)) {
       val job = Job()
       val scope = CoroutineScope(coroutineContext + BroadcastFrameClock())
+      var value = 0
 
       job.cancel()
 
-      scope.launchMolecule<Int>(mode, emitter = { fail() }, context = job) {
-        fail()
+      scope.launchMolecule<Int>(mode, emitter = { value = it }, context = job) {
+        1
       }
+      runCurrent()
+
+      assertThat(value).isEqualTo(1)
+      assertThat(job.children.toList()).isEmpty()
     }
   }
 

--- a/molecule-runtime/src/commonTest/kotlin/app/cash/molecule/MoleculeTest.kt
+++ b/molecule-runtime/src/commonTest/kotlin/app/cash/molecule/MoleculeTest.kt
@@ -34,14 +34,13 @@ import app.cash.molecule.SnapshotNotifier.External
 import app.cash.molecule.SnapshotNotifier.WhileActive
 import assertk.assertFailure
 import assertk.assertThat
+import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotSameInstanceAs
 import assertk.assertions.isSameInstanceAs
 import assertk.assertions.isTrue
 import kotlin.test.Test
-import kotlin.test.assertFailsWith
 import kotlin.test.fail
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -112,21 +111,20 @@ class MoleculeTest {
       }
     }.isSameInstanceAs(runtimeException)
 
-    // This exception is processed in `composeInitial` and not `runRecomposeAndApplyChanges`, so the job is still active.
+    runCurrent()
+    assertThat(job.children.toList()).isEmpty()
     job.cancelAndJoin()
   }
 
-  @Test fun cancelledContextFailsBeforeComposing() = runTest {
+  @Test fun cancelledContextReturnsBeforeComposing() = runTest {
     for (mode in listOf(ContextClock, Immediate)) {
       val job = Job()
       val scope = CoroutineScope(coroutineContext + BroadcastFrameClock())
 
       job.cancel()
 
-      assertFailsWith<CancellationException> {
-        scope.launchMolecule<Int>(mode, emitter = { fail() }, context = job) {
-          fail()
-        }
+      scope.launchMolecule<Int>(mode, emitter = { fail() }, context = job) {
+        fail()
       }
     }
   }
@@ -201,7 +199,8 @@ class MoleculeTest {
       }
     }.isSameInstanceAs(runtimeException)
 
-    // This exception is processed in `composeInitial` and not `runRecomposeAndApplyChanges`, so the job is still active.
+    runCurrent()
+    assertThat(job.children.toList()).isEmpty()
     job.cancelAndJoin()
   }
 


### PR DESCRIPTION
Fixes https://github.com/cashapp/molecule/issues/760

Ensures launchMolecule completes its synchronous initial composition and produces one value even when its launch context is already cancelled. Cancellation still prevents launched effects and future recompositions.

Keeps composition and snapshot observer cleanup tied to recomposer completion, and cancels the recomposer when initial composition or emitter code fails so startup resources do not leak.